### PR TITLE
[codex] Add priority, evaluation, and content workflows

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -40,6 +40,8 @@ Read first:
 - evaluation runs use synthetic fixtures by default and only write to Observability when an operator explicitly publishes failed gates
 - the webapp now exposes `Content Generation` for producing email subject lines, ad copy, social posts, and landing-page copy from existing company, product, goal, topic, and competitor context
 - content generation persists outputs as `CreativeDraft` records and records generation/audit events without automated posting
+- the webapp now exposes `Athlete App` beside the coach/operator surfaces so athletes can see coach-assigned checklist work, record daily activity, and mark assigned work complete
+- athlete records persist as `AthleteActivityLog` entries keyed by company, athlete email, day, and optional assigned task
 
 ## Files That Matter Most
 
@@ -65,6 +67,7 @@ System:
 - [scripts/lib/pipeline-jobs.js](/Users/Shared/Projects/checklist/scripts/lib/pipeline-jobs.js)
 - [src/lib/evaluation-bench.ts](/Users/Shared/Projects/checklist/src/lib/evaluation-bench.ts)
 - [src/lib/content-generation.ts](/Users/Shared/Projects/checklist/src/lib/content-generation.ts)
+- [src/lib/athlete-activity.ts](/Users/Shared/Projects/checklist/src/lib/athlete-activity.ts)
 
 ## Do Not Reintroduce
 
@@ -119,3 +122,4 @@ The work is not done until:
 - Frontier recompute assigns tactical columns by blended priority thresholds, not raw ICE alone, while preserving manual human drag/drop anchors.
 - Evaluation bench replay is advisory first: synthetic fixtures and rubric gates compare baseline vs candidate behavior without production writes unless failed gates are explicitly published to Observability.
 - Content generation is draft-only: it can create and persist channel-specific copy, but it must not post externally or generate images in the first release.
+- Athlete app is athlete-facing: it records daily activity and completion evidence but does not replace the coach/operator planning surfaces.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -21,6 +21,7 @@ Read first:
 - interactions are centralized in the shared UI layer
 - semantic tones are the only approved product color vocabulary
 - ICE management is centralized through shared scoring contracts plus oldest-first maintenance and queue flows across upstream cards, knowledge, goals, and tasks
+- tactical prioritization now uses the shared blended priority profile from `scoring-contract.js`; ICE remains visible, but placement also explains quality, urgency, freshness, human signal, risk, lifecycle state, and memory inputs
 - repetitive local-AI work is represented as persisted `PipelineJob` queue records
 - the webapp `Worker Queue` is the primary HiTL steering surface for repetitive jobs
 - worker scheduling supports explicit `AI_ONLY` and `HUMAN_GUIDED` modes
@@ -35,6 +36,10 @@ Read first:
 - workflow blueprints and enrichment waterfall policies are persisted system contracts, not local page-only state
 - active workflow blueprints now become first-class `PipelineJob` records that the worker can claim and execute
 - enrichment waterfall policy now influences runtime URL-intelligence provider selection for product and competitor research paths
+- the webapp now exposes `Evaluation Bench` as the first advisory promotion-gate surface for recommendation, grounded-answer, search, KPI, workflow, competitor, and data-readiness behavior
+- evaluation runs use synthetic fixtures by default and only write to Observability when an operator explicitly publishes failed gates
+- the webapp now exposes `Content Generation` for producing email subject lines, ad copy, social posts, and landing-page copy from existing company, product, goal, topic, and competitor context
+- content generation persists outputs as `CreativeDraft` records and records generation/audit events without automated posting
 
 ## Files That Matter Most
 
@@ -58,6 +63,8 @@ System:
 - [docs/SYSTEM_DESIGN_LLD.md](/Users/Shared/Projects/checklist/docs/SYSTEM_DESIGN_LLD.md)
 - [src/lib/pipeline-queue.js](/Users/Shared/Projects/checklist/src/lib/pipeline-queue.js)
 - [scripts/lib/pipeline-jobs.js](/Users/Shared/Projects/checklist/scripts/lib/pipeline-jobs.js)
+- [src/lib/evaluation-bench.ts](/Users/Shared/Projects/checklist/src/lib/evaluation-bench.ts)
+- [src/lib/content-generation.ts](/Users/Shared/Projects/checklist/src/lib/content-generation.ts)
 
 ## Do Not Reintroduce
 
@@ -109,3 +116,6 @@ The work is not done until:
 - Human drag-and-drop on the `Worker Queue` board switches jobs into `HUMAN_GUIDED` mode.
 - `Reset to AI only` clears manual queue influence and returns scheduling to autonomous control.
 - Score-health alert repair is now able to escalate queue work through the shared queue contract.
+- Frontier recompute assigns tactical columns by blended priority thresholds, not raw ICE alone, while preserving manual human drag/drop anchors.
+- Evaluation bench replay is advisory first: synthetic fixtures and rubric gates compare baseline vs candidate behavior without production writes unless failed gates are explicitly published to Observability.
+- Content generation is draft-only: it can create and persist channel-specific copy, but it must not post externally or generate images in the first release.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -40,7 +40,8 @@ Read first:
 - evaluation runs use synthetic fixtures by default and only write to Observability when an operator explicitly publishes failed gates
 - the webapp now exposes `Content Generation` for producing email subject lines, ad copy, social posts, and landing-page copy from existing company, product, goal, topic, and competitor context
 - content generation persists outputs as `CreativeDraft` records and records generation/audit events without automated posting
-- the webapp now exposes `Athlete App` beside the coach/operator surfaces so athletes can see coach-assigned checklist work, record daily activity, and mark assigned work complete
+- the webapp now exposes `Athlete App` beside the coach/operator surfaces so athletes can see coach-assigned checklist work, record daily activity, wellness/body metrics, and mark assigned work complete
+- the webapp also exposes `Athletes` as the coach-facing records view for team daily logs, completion evidence, readiness, load, sleep, soreness, and pain flags
 - athlete records persist as `AthleteActivityLog` entries keyed by company, athlete email, day, and optional assigned task
 
 ## Files That Matter Most
@@ -122,4 +123,5 @@ The work is not done until:
 - Frontier recompute assigns tactical columns by blended priority thresholds, not raw ICE alone, while preserving manual human drag/drop anchors.
 - Evaluation bench replay is advisory first: synthetic fixtures and rubric gates compare baseline vs candidate behavior without production writes unless failed gates are explicitly published to Observability.
 - Content generation is draft-only: it can create and persist channel-specific copy, but it must not post externally or generate images in the first release.
-- Athlete app is athlete-facing: it records daily activity and completion evidence but does not replace the coach/operator planning surfaces.
+- Athlete app is athlete-facing: it records daily activity, wellness/body metrics, and completion evidence but does not replace the coach/operator planning surfaces.
+- Athlete records is coach-facing: it can summarize team submissions, but planning and assignment still stay in the coach/operator checklist surfaces.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ New operator surfaces:
 - enrichment-waterfall policies now affect runtime provider selection for URL intelligence instead of living as config-only records
 - `/:companyId/evaluations` provides an advisory evaluation bench for recommendation, grounded-answer, search, KPI, workflow, competitor, and data-readiness behavior before intelligence changes are promoted
 - `/:companyId/content-generation` generates and saves evidence-aware email subjects, platform ad copy, social posts, and landing-page sections from product and competitor context
+- `/:companyId/athlete` provides an athlete-facing daily app for coach-assigned work, activity recording, wellness/readiness notes, and completion records
 
 Knowmore evidence durability:
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ New operator surfaces:
 - enrichment-waterfall policies now affect runtime provider selection for URL intelligence instead of living as config-only records
 - `/:companyId/evaluations` provides an advisory evaluation bench for recommendation, grounded-answer, search, KPI, workflow, competitor, and data-readiness behavior before intelligence changes are promoted
 - `/:companyId/content-generation` generates and saves evidence-aware email subjects, platform ad copy, social posts, and landing-page sections from product and competitor context
-- `/:companyId/athlete` provides an athlete-facing daily app for coach-assigned work, activity recording, wellness/readiness notes, and completion records
+- `/:companyId/athlete` provides an athlete-facing daily app for coach-assigned work, activity recording, wellness/body metrics, readiness notes, and completion records
+- `/:companyId/athletes` provides a coach-facing athlete records view for daily team logs, completion evidence, load, sleep, soreness, readiness, and pain flags
 
 Knowmore evidence durability:
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Frontend system:
 - first-class entity card surfaces must expose their canonical ICE score through the shared card header contract
 - Typography is defined centrally in the Mantine theme and DS typography primitives only
 - ICE management must run through the canonical scoring contract and the oldest-first maintenance queue across upstream cards, knowledge, goals, and tasks
+- tactical placement uses the shared blended priority contract: ICE remains visible, while ranking also accounts for quality, urgency, freshness, human signal, risk, lifecycle state, and memory signal
 - source-backed Knowmore cards must persist durable citation snapshots and explicit conflict state instead of relying on raw URLs alone
 
 Worker queue controls:
@@ -69,6 +70,8 @@ New operator surfaces:
 - `/:companyId/workflows` provides bounded workflow blueprints and enrichment-waterfall policy management
 - active workflow blueprints are not passive records: they materialize into claimable `WORKFLOW_BLUEPRINT` queue jobs and execute through the shared worker queue
 - enrichment-waterfall policies now affect runtime provider selection for URL intelligence instead of living as config-only records
+- `/:companyId/evaluations` provides an advisory evaluation bench for recommendation, grounded-answer, search, KPI, workflow, competitor, and data-readiness behavior before intelligence changes are promoted
+- `/:companyId/content-generation` generates and saves evidence-aware email subjects, platform ad copy, social posts, and landing-page sections from product and competitor context
 
 Knowmore evidence durability:
 

--- a/docs/LOCAL_AI_PIPELINE.md
+++ b/docs/LOCAL_AI_PIPELINE.md
@@ -386,9 +386,10 @@ The first content-generation contract is draft-only:
 
 The first athlete app contract is a daily recording loop beside the coach/operator app:
 
-- `AthleteActivityLog` stores athlete-entered activity, wellness/readiness, duration, intensity, notes, completion state, and optional linked checklist work
-- `/api/athlete` exposes the current athlete's assigned work plus their daily record behind normal company membership checks
+- `AthleteActivityLog` stores athlete-entered activity, wellness/readiness, sleep, soreness, stress, mood, hydration, body weight, pain/nutrition notes, duration, intensity, notes, completion state, and optional linked checklist work
+- `/api/athlete` exposes the current athlete's assigned work plus their daily record behind normal company membership checks, with an admin-scoped team summary mode for coaches
 - `/:companyId/athlete` lets athletes see what the coach set, record training/recovery/nutrition/wellness/match/note entries, and mark assigned work complete
+- `/:companyId/athletes` lets coaches review team daily records, completion evidence, readiness, load, sleep, soreness, and pain flags
 - completed assigned work writes audit/outcome events and archives the linked checklist item as completed
 - wearable integrations, medical claims, public sharing, and payment flows are out of scope for this first slice
 

--- a/docs/LOCAL_AI_PIPELINE.md
+++ b/docs/LOCAL_AI_PIPELINE.md
@@ -355,8 +355,32 @@ Important:
 - the app no longer uses mixed confidence scales
 - task generation/refinement must normalize through `src/lib/scoring-contract.js`
 - task scoring is grounded by source strength plus task specificity, urgency, and complexity signals
+- tactical placement uses the shared blended priority profile, not raw ICE alone
+- blended priority combines ICE, quality, urgency, freshness, human signal, risk, lifecycle state, and memory signal
+- `priorityProfile` exposes component-level reasons so ranking is inspectable
+- operator drag/drop anchors remain explicit human signal and are preserved ahead of AI-only ordering
 - periodic rescoring runs oldest-updated-first across active card layers
 - score clustering is observable through the dashboard score-health panel and `npm run audit:score-health`
+
+## Evaluation bench
+
+The first recommendation and agent evaluation contract is advisory:
+
+- `src/lib/evaluation-bench.ts` owns seeded synthetic fixture cases and rubrics for grounded answers, search ranking, KPI pulse behavior, workflow replay, competitive-change briefings, data-readiness warnings, and recommendation generation
+- `/api/evaluations` runs baseline-vs-candidate comparisons behind company membership checks
+- replay does not mutate production company data by default
+- failed gates can be explicitly published as `EVAL_GATE_FAILED` outcome events so Observability and pre-production evals share vocabulary
+- high-risk failed cases return `REVIEW_REQUIRED` or `BLOCK` promotion metadata before future enforcement is introduced
+
+## Content generation
+
+The first content-generation contract is draft-only:
+
+- `src/lib/content-generation.ts` derives channel-specific marketing copy from existing company, product, competitor, goal, topic, and task context
+- `/api/content-generation` persists generated outputs as `CreativeDraft` records and records generation/audit events
+- generated bundles include five email subject lines, Facebook/Google/LinkedIn ad copy, Twitter/LinkedIn/Facebook social posts, and landing-page hero/benefit/CTA sections
+- tone selection is explicit and bounded to clear, bold, executive, friendly, or technical
+- no automated posting, image generation, or multi-language output is part of this release
 
 ## Delivery modes
 

--- a/docs/LOCAL_AI_PIPELINE.md
+++ b/docs/LOCAL_AI_PIPELINE.md
@@ -382,6 +382,16 @@ The first content-generation contract is draft-only:
 - tone selection is explicit and bounded to clear, bold, executive, friendly, or technical
 - no automated posting, image generation, or multi-language output is part of this release
 
+## Athlete app
+
+The first athlete app contract is a daily recording loop beside the coach/operator app:
+
+- `AthleteActivityLog` stores athlete-entered activity, wellness/readiness, duration, intensity, notes, completion state, and optional linked checklist work
+- `/api/athlete` exposes the current athlete's assigned work plus their daily record behind normal company membership checks
+- `/:companyId/athlete` lets athletes see what the coach set, record training/recovery/nutrition/wellness/match/note entries, and mark assigned work complete
+- completed assigned work writes audit/outcome events and archives the linked checklist item as completed
+- wearable integrations, medical claims, public sharing, and payment flows are out of scope for this first slice
+
 ## Delivery modes
 
 There is one supported hosted execution mode:

--- a/docs/RULEBOOK.md
+++ b/docs/RULEBOOK.md
@@ -217,9 +217,10 @@ Content generation rules:
 Athlete app rules:
 
 - athlete-facing recording must be separate from coach/operator planning surfaces while reusing the same company membership boundary
-- daily athlete records must persist as `AthleteActivityLog` entries with activity type, date, optional linked assigned work, duration, intensity, readiness, notes, and completion state
+- daily athlete records must persist as `AthleteActivityLog` entries with activity type, date, optional linked assigned work, duration, intensity, readiness, wellness/body metrics, notes, and completion state
+- coach-facing athlete record review must require admin-level company membership while athlete self-entry uses normal company membership
 - athlete completion of coach-assigned work must record audit/outcome events and must not silently erase the original checklist context
-- athlete forms must support training, recovery, nutrition, wellness, match, and note records without requiring coach intervention
+- athlete forms must support training, recovery, nutrition, wellness, match, note, sleep, soreness, stress, mood, hydration, body-weight, pain, and nutrition records without requiring coach intervention
 - the first athlete app release must not add public sharing, medical claims, payment, or external wearable integrations
 
 ## 10. Mandatory Completion Rules

--- a/docs/RULEBOOK.md
+++ b/docs/RULEBOOK.md
@@ -214,6 +214,14 @@ Content generation rules:
 - generated copy must be persisted as `CreativeDraft` records and must remain editable outside the generator
 - content generation must record audit/generation events so future feedback loops can distinguish draft creation from campaign performance
 
+Athlete app rules:
+
+- athlete-facing recording must be separate from coach/operator planning surfaces while reusing the same company membership boundary
+- daily athlete records must persist as `AthleteActivityLog` entries with activity type, date, optional linked assigned work, duration, intensity, readiness, notes, and completion state
+- athlete completion of coach-assigned work must record audit/outcome events and must not silently erase the original checklist context
+- athlete forms must support training, recovery, nutrition, wellness, match, and note records without requiring coach intervention
+- the first athlete app release must not add public sharing, medical claims, payment, or external wearable integrations
+
 ## 10. Mandatory Completion Rules
 
 Work is not complete if any of the following are true:

--- a/docs/RULEBOOK.md
+++ b/docs/RULEBOOK.md
@@ -42,6 +42,7 @@ Approved product UI system:
 - first-class entity card surfaces must expose canonical ICE through the shared card header contract
 - semantic tones only for product color meaning
 - ICE updates, rescoring, and repair must run through shared scoring contracts and oldest-first maintenance or queue flows, not local ad hoc math
+- tactical placement must use the shared blended priority contract, which keeps ICE visible but ranks work through explainable ICE, quality, urgency, freshness, human-signal, risk, lifecycle-state, and memory inputs
 - source-backed knowledge must persist durable citation snapshots and explicit conflict state; URL-only provenance is not accepted
 
 ## 3. What We Do Not Use
@@ -197,6 +198,22 @@ Required update matrix:
   - update `HANDOVER.md`
   - update `DESIGN_SYSTEM_AGENT_HANDOFF.md` if UI-related
 
+Evaluation bench rules:
+
+- intelligence changes that affect recommendations, grounded answers, retrieval, workflow behavior, KPI pulses, competitor briefings, or data-readiness warnings must be representable as seeded evaluation cases
+- evaluation replay must be non-mutating by default and must use synthetic fixture data unless an operator explicitly requests Observability publication
+- case results must expose explainable rubric scores and reasons, not only aggregate percentages
+- failed high-risk gates start as `REVIEW_REQUIRED` or `BLOCK` metadata; enforcement can become stricter only after the rubric is stable
+- eval failures published to Observability must use `EVAL_GATE_FAILED` so production regressions and pre-production gates share vocabulary
+
+Content generation rules:
+
+- generated marketing copy must be grounded in existing company, product, competitor, goal, topic, or task context
+- the first release is draft-only and must not automate posting, image generation, or external campaign activation
+- channel outputs must preserve platform-specific formats and character-limit metadata
+- generated copy must be persisted as `CreativeDraft` records and must remain editable outside the generator
+- content generation must record audit/generation events so future feedback loops can distinguish draft creation from campaign performance
+
 ## 10. Mandatory Completion Rules
 
 Work is not complete if any of the following are true:
@@ -256,3 +273,16 @@ Rules:
 - do not document or imply a separate tweak menu unless it actually exists in the webapp
 - suspicious or critical score-health states must be able to reprioritize queue work through the shared queue contract
 - fairness-sensitive recalculation work must continue to preserve oldest-first behavior unless explicitly human-overridden
+
+## 14. Blended Priority Rules
+
+Raw ICE is the user-visible score, not the only ranking authority.
+
+Rules:
+
+- `src/lib/scoring-contract.js` owns the canonical blended priority profile
+- the blended profile must expose both a numeric priority score and component-level reasons
+- supported priority components are ICE, quality, urgency, freshness, human signal, risk, lifecycle state, and memory signal
+- human-guided planning anchors must remain visible and must not be silently erased by AI reprioritization
+- frontier placement and tactical board ordering must use blended priority where available
+- feature code must not invent local ranking math for tactical placement

--- a/docs/SSOT.md
+++ b/docs/SSOT.md
@@ -99,6 +99,17 @@ The current intelligence-operations contract also includes:
 - observability also owns bounded repair actions for queue sync, score-repair escalation, and failed-job recovery
 - persisted workflow blueprints for bounded automation building, materialized as real worker-queue jobs when active
 - persisted enrichment waterfall policies for provider ordering and fallback governance, applied at runtime during URL intelligence enrichment
+- one advisory evaluation bench for replaying seeded synthetic intelligence cases before recommendation, grounded-answer, ranking, workflow, and data-readiness changes are promoted
+- evaluation failures can be explicitly published into Observability as `EVAL_GATE_FAILED` outcome events; normal replay does not mutate production company data
+- one content-generation surface that turns existing company, product, goal, topic, and competitor context into saved `CreativeDraft` records for email subjects, ads, social posts, and landing-page copy
+- content generation is draft-only in the current contract: no automated posting, no image generation, and no multi-language generation
+
+Tactical placement contract:
+
+- `iceScore` remains the visible score on task cards
+- `priorityProfile` is the ranking explanation used for tactical ordering and frontier placement
+- human drag/drop anchors remain explicit human guidance and are not silently erased by AI scoring
+- priority thresholds are applied to blended priority scores, not raw ICE alone
 
 ## 6. AI Brain Rule
 

--- a/docs/SSOT.md
+++ b/docs/SSOT.md
@@ -103,6 +103,8 @@ The current intelligence-operations contract also includes:
 - evaluation failures can be explicitly published into Observability as `EVAL_GATE_FAILED` outcome events; normal replay does not mutate production company data
 - one content-generation surface that turns existing company, product, goal, topic, and competitor context into saved `CreativeDraft` records for email subjects, ads, social posts, and landing-page copy
 - content generation is draft-only in the current contract: no automated posting, no image generation, and no multi-language generation
+- one athlete-facing daily app beside the coach/operator app, backed by `AthleteActivityLog`, where athletes can see assigned checklist work, record activity, readiness, intensity, notes, and completion evidence
+- completing coach-assigned work from the athlete app records an athlete outcome and archives the assigned checklist item as completed
 
 Tactical placement contract:
 

--- a/docs/SSOT.md
+++ b/docs/SSOT.md
@@ -103,7 +103,8 @@ The current intelligence-operations contract also includes:
 - evaluation failures can be explicitly published into Observability as `EVAL_GATE_FAILED` outcome events; normal replay does not mutate production company data
 - one content-generation surface that turns existing company, product, goal, topic, and competitor context into saved `CreativeDraft` records for email subjects, ads, social posts, and landing-page copy
 - content generation is draft-only in the current contract: no automated posting, no image generation, and no multi-language generation
-- one athlete-facing daily app beside the coach/operator app, backed by `AthleteActivityLog`, where athletes can see assigned checklist work, record activity, readiness, intensity, notes, and completion evidence
+- one athlete-facing daily app beside the coach/operator app, backed by `AthleteActivityLog`, where athletes can see assigned checklist work, record activity, readiness, intensity, sleep, soreness, stress, mood, hydration, body weight, pain/nutrition notes, and completion evidence
+- one coach-facing athlete records view where admins can review team daily submissions, completion evidence, load, readiness, sleep, soreness, and pain flags
 - completing coach-assigned work from the athlete app records an athlete outcome and archives the assigned checklist item as completed
 
 Tactical placement contract:

--- a/docs/SYSTEM_DESIGN_LLD.md
+++ b/docs/SYSTEM_DESIGN_LLD.md
@@ -123,3 +123,27 @@ The repetitive-job system now has a first-class queue model:
 - `observability.ts` aggregates heartbeat, queue, score-health, worker reports, and recent outcomes for mission-control surfaces, and drives bounded repair recommendations
 - `workflow-blueprints.ts` owns the persisted bounded workflow-builder contract and default blueprint registry; active blueprints are synchronized into `PipelineJob` records and executed by the shared queue worker
 - `enrichment-waterfall.ts` owns the persisted provider-ordering and fallback policy contract for enrichment governance, and `url-enrichment.ts` consumes that policy at runtime for product/competitor research
+
+## 9. Blended Priority Architecture
+
+- `scoring-contract.js` owns `computeBlendedPriorityProfile`
+- the profile returns a bounded priority score, component signals, weights, lifecycle and memory multipliers, and short reason labels
+- frontier recomputation uses the blended priority score for rank and tactical column thresholds while preserving raw ICE as the visible card score
+- tactical API responses include `priorityProfile` so the board can explain why an item is ranked where it is
+- manual planning anchors from drag/drop remain first-class human signal and are preserved ahead of AI-only priority ordering
+
+## 10. Evaluation Bench Architecture
+
+- `evaluation-bench.ts` owns the seeded synthetic fixtures, case definitions, rubric weights, replay scorer, baseline-vs-candidate comparison, and promotion-gate metadata
+- `/api/evaluations` runs the bench behind normal company membership checks and is non-mutating by default
+- `/:companyId/evaluations` is the operator surface for running advisory replay, reviewing case-level reasons, and comparing candidate behavior to the current baseline
+- failed gates can be explicitly published to Observability as `EVAL_GATE_FAILED` outcome events so eval failures and production regressions share terminology
+- evaluation cases use synthetic fixture markers and tenant-isolation scoring so the bench does not reward cross-tenant or live-data leakage
+
+## 11. Content Generation Architecture
+
+- `content-generation.ts` owns the deterministic first-slice content-generation contract for tone profiles, positioning extraction, platform limits, and channel-specific output formatting
+- `/api/content-generation` runs behind normal company membership checks, reads existing company/product/competitor/goal/topic/task context, and persists generated outputs as `CreativeDraft` records
+- `/:companyId/content-generation` is the operator surface for choosing tone, adding an optional campaign brief, generating content, copying outputs, and reviewing recent drafts
+- generated bundles include exactly five email subject lines, Facebook/Google/LinkedIn ad copy, Twitter/LinkedIn/Facebook social posts, and landing-page hero/benefit/CTA copy
+- the current release is draft-only: it does not post externally, generate images, or claim multi-language output

--- a/docs/SYSTEM_DESIGN_LLD.md
+++ b/docs/SYSTEM_DESIGN_LLD.md
@@ -147,3 +147,11 @@ The repetitive-job system now has a first-class queue model:
 - `/:companyId/content-generation` is the operator surface for choosing tone, adding an optional campaign brief, generating content, copying outputs, and reviewing recent drafts
 - generated bundles include exactly five email subject lines, Facebook/Google/LinkedIn ad copy, Twitter/LinkedIn/Facebook social posts, and landing-page hero/benefit/CTA copy
 - the current release is draft-only: it does not post externally, generate images, or claim multi-language output
+
+## 12. Athlete App Architecture
+
+- `AthleteActivityLog` is the persisted daily athlete record, keyed by company, athlete email, activity date, and optional assigned checklist item
+- `athlete-activity.ts` owns activity-type normalization, bounded score/duration handling, day-window calculation, and daily summary math
+- `/api/athlete` runs behind normal company membership checks and returns the current athlete's assigned work plus their daily activity log
+- `/:companyId/athlete` is the athlete-facing surface for coach-assigned work, activity recording, wellness/readiness notes, and completion evidence
+- completing assigned work from the athlete app records an audit/outcome event and moves the linked checklist item to completed/archived state

--- a/docs/SYSTEM_DESIGN_LLD.md
+++ b/docs/SYSTEM_DESIGN_LLD.md
@@ -151,7 +151,8 @@ The repetitive-job system now has a first-class queue model:
 ## 12. Athlete App Architecture
 
 - `AthleteActivityLog` is the persisted daily athlete record, keyed by company, athlete email, activity date, and optional assigned checklist item
-- `athlete-activity.ts` owns activity-type normalization, bounded score/duration handling, day-window calculation, and daily summary math
-- `/api/athlete` runs behind normal company membership checks and returns the current athlete's assigned work plus their daily activity log
-- `/:companyId/athlete` is the athlete-facing surface for coach-assigned work, activity recording, wellness/readiness notes, and completion evidence
+- `athlete-activity.ts` owns activity-type normalization, bounded score/duration/metrics handling, day-window calculation, and daily/team summary math
+- `/api/athlete` runs behind normal company membership checks for self records and supports an admin-scoped `scope=team` view for coach review
+- `/:companyId/athlete` is the athlete-facing surface for coach-assigned work, activity recording, wellness/body metrics, readiness notes, pain/nutrition notes, and completion evidence
+- `/:companyId/athletes` is the coach-facing records surface for team daily submissions, load, completion evidence, readiness, sleep, soreness, and pain flags
 - completing assigned work from the athlete app records an audit/outcome event and moves the linked checklist item to completed/archived state

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model Company {
   topics              Topic[]
   uploadedSourceFiles UploadedSourceFile[]
   creativeDrafts      CreativeDraft[]
+  athleteActivityLogs AthleteActivityLog[]
   workerConfig        Json?                 @default("{}")
   lastAIVisited       DateTime?
   users               User[]
@@ -123,6 +124,29 @@ model Feedback {
   deliveryComment     String?     // High-value memory input on DELIVER
   actorId             String?     // User who performed the action
   nbaItem             NBAItem     @relation(fields: [nbaItemId], references: [id])
+}
+
+model AthleteActivityLog {
+  id              String   @id @default(uuid()) @map("_id")
+  companyId       String
+  athleteEmail    String
+  athleteName     String?
+  nbaItemId       String?
+  activityDate    DateTime @default(now())
+  activityType    String   @default("TRAINING")
+  title           String
+  notes           String?
+  durationMinutes Int?
+  intensity       Int?
+  readiness       Int?
+  completionState String   @default("RECORDED")
+  metrics         Json?    @default("{}")
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @default(now()) @updatedAt
+  company         Company  @relation(fields: [companyId], references: [id], onDelete: Cascade)
+
+  @@index([companyId, athleteEmail, activityDate])
+  @@index([companyId, nbaItemId, activityDate])
 }
 
 enum IntelligenceType {

--- a/scripts/lib/frontier.js
+++ b/scripts/lib/frontier.js
@@ -6,6 +6,7 @@
  */
 const { CandidateState } = require("./lifecycle");
 const { recordDecisionEvent, recordOutcomeEvent } = require("./audit-ledger");
+const { computeBlendedPriorityProfile } = require("../../src/lib/scoring-contract");
 
 // ---------------------------------------------------------------------------
 // 1. Configuration
@@ -34,32 +35,10 @@ const ROT_DAYS = 14;
  * @returns {number} frontier score (higher = more surfaceable)
  */
 function computeFrontierScore(candidate) {
-  const stateWeight = STATE_WEIGHTS[candidate.candidateState] ?? 0.45;
-
-  const qualityWeight = candidate.qualityScore !== null && candidate.qualityScore !== undefined
-    ? candidate.qualityScore
-    : (candidate.iceScore || 0) / 1000; // normalize legacy ICE
-
-  const urgencyWeight = candidate.urgencyScore !== null && candidate.urgencyScore !== undefined
-    ? candidate.urgencyScore
-    : (candidate.impact || 5) / 10;
-
-  const freshnessWeight = candidate.freshnessScore !== null && candidate.freshnessScore !== undefined
-    ? candidate.freshnessScore
-    : computeImpliedFreshness(candidate);
-
-  const feedbackWeight = normalizeFeedbackScore(candidate.feedbackScore || 0);
-
-  // Priority boost for explicitly topic-pinned or high-ICE items
-  const priorityWeight = candidate.iceScore >= 500 ? 1.1 : 1.0;
-
-  // Kanban Manual Priority Override (§24)
-  // userPriority is represented by sortOrder. If sortOrder < 0, it acts as a massive boost.
-  const userPriorityMultiplier = candidate.sortOrder < 0 ? Math.abs(candidate.sortOrder) * 10 : 1.0;
-
-  const memoryMultiplier = candidate._memoryMultiplier ?? 1.0;
-
-  return stateWeight * qualityWeight * urgencyWeight * freshnessWeight * feedbackWeight * priorityWeight * userPriorityMultiplier * memoryMultiplier;
+  return computeBlendedPriorityProfile({
+    ...candidate,
+    memoryMultiplier: candidate._memoryMultiplier ?? 1,
+  }).score;
 }
 
 function tokenize(value) {
@@ -108,19 +87,6 @@ async function loadFrontierMemoryEntries(prisma, companyId) {
     orderBy: [{ weight: "desc" }, { updatedAt: "desc" }],
     take: 20,
   });
-}
-
-function computeImpliedFreshness(candidate) {
-  const ageMs = Date.now() - new Date(candidate.updatedAt || candidate.createdAt || Date.now()).getTime();
-  const windowMs = 30 * 24 * 60 * 60 * 1000;
-  return Math.max(0.1, 1 - ageMs / windowMs);
-}
-
-function normalizeFeedbackScore(raw) {
-  // Clamp accumulated feedback signal to [0.5, 2.0] multiplier range
-  if (raw > 0) return Math.min(2.0, 1.0 + raw * 0.1);
-  if (raw < 0) return Math.max(0.5, 1.0 + raw * 0.1);
-  return 1.0;
 }
 
 function isRotten(candidate) {
@@ -217,10 +183,15 @@ async function recomputeFrontier(prisma, company, cycleRunId = null) {
   // 2. Attach scores
   const scored = all.map((candidate) => {
     const memoryMultiplier = computeFrontierMemoryMultiplier(candidate, frontierMemoryEntries);
+    const priorityProfile = computeBlendedPriorityProfile({
+      ...candidate,
+      memoryMultiplier,
+    });
     return {
       ...candidate,
       _memoryMultiplier: memoryMultiplier,
-      _frontierScore: computeFrontierScore({ ...candidate, _memoryMultiplier: memoryMultiplier }),
+      _priorityProfile: priorityProfile,
+      _frontierScore: priorityProfile.score,
     };
   });
 
@@ -235,18 +206,20 @@ async function recomputeFrontier(prisma, company, cycleRunId = null) {
   deduplicated.sort((a, b) => b._frontierScore - a._frontierScore);
 
   // ---------------------------------------------------------------------------
-  // 6. ICE-Threshold Column Distribution (§24)
+  // 6. Blended-Priority Column Distribution (§24)
   // ---------------------------------------------------------------------------
-  // Cards earn their column by ICE score. Higher ICE = closer to execution.
+  // Cards earn their AI-selected column by blended priority, not raw ICE alone.
+  // ICE remains the visible card score; frontier placement blends ICE, quality,
+  // urgency, freshness, human signal, risk, lifecycle state, and memory signal.
   // Thresholds are intentional gates — a card must improve to advance.
   //
-  //   CHECKLIST  : ICE >= 700 (hard-capped at FRONTIER_MAX_SIZE = 3)
-  //   TODO       : ICE >= 500
-  //   BACKLOG    : ICE >= 250
-  //   ROADMAP    : ICE >= 100
-  //   IDEABANK   : ICE <  100  (default holding pen for all new cards)
+  //   CHECKLIST  : priority >= 700 (hard-capped at FRONTIER_MAX_SIZE = 3)
+  //   TODO       : priority >= 500
+  //   BACKLOG    : priority >= 250
+  //   ROADMAP    : priority >= 100
+  //   IDEABANK   : priority <  100  (default holding pen for all new cards)
 
-  const ICE_THRESHOLD = {
+  const PRIORITY_THRESHOLD = {
     CHECKLIST: 700,
     TODO:      500,
     BACKLOG:   250,
@@ -262,7 +235,7 @@ async function recomputeFrontier(prisma, company, cycleRunId = null) {
   ];
 
   for (const item of deduplicated) {
-    const ice = item.iceScore || 0;
+    const priority = item._priorityProfile?.score ?? item._frontierScore ?? 0;
 
     // Respect user-set hard priority (sortOrder < 0) — Anchor in their current column
     if (item.sortOrder < 0 && item.kanbanColumn) {
@@ -274,13 +247,13 @@ async function recomputeFrontier(prisma, company, cycleRunId = null) {
       } else {
         targetCol.items.push(item);
       }
-    } else if (ice >= ICE_THRESHOLD.CHECKLIST && columnMap[0].items.length < FRONTIER_MAX_SIZE) {
+    } else if (priority >= PRIORITY_THRESHOLD.CHECKLIST && columnMap[0].items.length < FRONTIER_MAX_SIZE) {
       columnMap[0].items.push(item);
-    } else if (ice >= ICE_THRESHOLD.TODO) {
+    } else if (priority >= PRIORITY_THRESHOLD.TODO) {
       columnMap[1].items.push(item);
-    } else if (ice >= ICE_THRESHOLD.BACKLOG) {
+    } else if (priority >= PRIORITY_THRESHOLD.BACKLOG) {
       columnMap[2].items.push(item);
-    } else if (ice >= ICE_THRESHOLD.ROADMAP) {
+    } else if (priority >= PRIORITY_THRESHOLD.ROADMAP) {
       columnMap[3].items.push(item);
     } else {
       columnMap[4].items.push(item);
@@ -308,15 +281,18 @@ async function recomputeFrontier(prisma, company, cycleRunId = null) {
         frontierRank: rank + 1,
       },
       payload: {
-        frontierScore: item._frontierScore,
-        checklistThreshold: 700,
-        todoThreshold: 500,
-        backlogThreshold: 250,
-        roadmapThreshold: 100,
+        blendedPriorityScore: item._frontierScore,
+        priorityProfile: item._priorityProfile,
+        checklistThreshold: PRIORITY_THRESHOLD.CHECKLIST,
+        todoThreshold: PRIORITY_THRESHOLD.TODO,
+        backlogThreshold: PRIORITY_THRESHOLD.BACKLOG,
+        roadmapThreshold: PRIORITY_THRESHOLD.ROADMAP,
         manualPriority: item.sortOrder < 0,
         memoryMultiplier: item._memoryMultiplier ?? 1,
       },
-      rationale: item.sortOrder < 0 ? "User-prioritized hard anchor respected during frontier recompute" : "Column assigned by ICE threshold and frontier score",
+      rationale: item.sortOrder < 0
+        ? "User-prioritized hard anchor respected during blended-priority frontier recompute"
+        : `Column assigned by blended priority: ${item._priorityProfile?.reasons?.join(", ") ?? "no reasons"}`,
       teachingWeight: targetColumn === "CHECKLIST" ? 80 : 60,
       cycleRunId,
     });
@@ -356,7 +332,8 @@ async function recomputeFrontier(prisma, company, cycleRunId = null) {
             scheduledDate: group.column === "CHECKLIST" ? new Date() : null,
           },
           payload: {
-            frontierScore: item._frontierScore,
+            blendedPriorityScore: item._frontierScore,
+            priorityProfile: item._priorityProfile,
           },
           teachingWeight: group.column === "CHECKLIST" ? 80 : 60,
           cycleRunId,

--- a/src/app/[companyId]/athlete/page.tsx
+++ b/src/app/[companyId]/athlete/page.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import {
+  Badge,
+  Button,
+  Group,
+  Loader,
+  NumberInput,
+  SegmentedControl,
+  SimpleGrid,
+  Stack,
+  Table,
+  TextInput,
+  Textarea,
+} from "@mantine/core";
+import {
+  IconActivity as Activity,
+  IconCalendarCheck as CalendarCheck,
+  IconChecks as Checks,
+  IconHeartbeat as Heartbeat,
+  IconRun as Run,
+  IconUserCheck as UserCheck,
+} from "@tabler/icons-react";
+import { MetricCard, Notice, PageHeader, PageShell } from "@/components/ui/app-shell";
+import { BodyText, MetaText } from "@/components/ui/typography";
+import { UnifiedCard, UnifiedCardBody, UnifiedCardHeader } from "@/components/ui/unified-card";
+import { ATHLETE_ACTIVITY_TYPES, type AthleteActivityType } from "@/lib/athlete-activity";
+
+type AssignedWork = {
+  id: string;
+  publicId: number | null;
+  title: string;
+  description?: string | null;
+  scheduledDate?: string | null;
+  kanbanColumn: string;
+  iceScore: number;
+};
+
+type AthleteLog = {
+  id: string;
+  activityDate: string;
+  activityType: string;
+  title: string;
+  notes?: string | null;
+  durationMinutes?: number | null;
+  intensity?: number | null;
+  readiness?: number | null;
+  completionState: string;
+  createdAt: string;
+  nbaItemId?: string | null;
+};
+
+type AthletePayload = {
+  date: string;
+  athlete: {
+    email: string;
+    name?: string | null;
+  };
+  assignedWork: AssignedWork[];
+  logs: AthleteLog[];
+  summary: {
+    totalLogs: number;
+    completed: number;
+    totalMinutes: number;
+    averageReadiness: number | null;
+    averageIntensity: number | null;
+  };
+};
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+export default function AthletePage() {
+  const params = useParams();
+  const companyId = params.companyId as string;
+  const [date, setDate] = useState(today());
+  const [data, setData] = useState<AthletePayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [activityType, setActivityType] = useState<AthleteActivityType>("TRAINING");
+  const [title, setTitle] = useState("");
+  const [notes, setNotes] = useState("");
+  const [durationMinutes, setDurationMinutes] = useState<number | "">(45);
+  const [intensity, setIntensity] = useState<number | "">(6);
+  const [readiness, setReadiness] = useState<number | "">(7);
+
+  const loadDay = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/athlete?companyId=${companyId}&date=${date}`);
+      setData(await response.json());
+    } finally {
+      setLoading(false);
+    }
+  }, [companyId, date]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void loadDay();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [loadDay]);
+
+  const resetForm = () => {
+    setTitle("");
+    setNotes("");
+    setDurationMinutes(45);
+    setIntensity(6);
+    setReadiness(7);
+    setActivityType("TRAINING");
+  };
+
+  const recordActivity = useCallback(async (options?: { work?: AssignedWork; completed?: boolean }) => {
+    const work = options?.work;
+    const resolvedTitle = work?.title || title.trim();
+    if (!resolvedTitle) return;
+
+    setSaving(true);
+    try {
+      await fetch("/api/athlete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          companyId,
+          activityDate: date,
+          activityType: work ? "TRAINING" : activityType,
+          title: resolvedTitle,
+          notes: work ? notes || "Coach-assigned work completed." : notes,
+          durationMinutes,
+          intensity,
+          readiness,
+          nbaItemId: work?.id,
+          completionState: options?.completed ? "COMPLETED" : "RECORDED",
+        }),
+      });
+      resetForm();
+      await loadDay();
+    } finally {
+      setSaving(false);
+    }
+  }, [activityType, companyId, date, durationMinutes, intensity, loadDay, notes, readiness, title]);
+
+  if (loading) {
+    return (
+      <PageShell width="full">
+        <Stack align="center" py="xl">
+          <Loader />
+        </Stack>
+      </PageShell>
+    );
+  }
+
+  const summary = data?.summary || {
+    totalLogs: 0,
+    completed: 0,
+    totalMinutes: 0,
+    averageReadiness: null,
+    averageIntensity: null,
+  };
+  const assignedWork = data?.assignedWork || [];
+  const logs = data?.logs || [];
+
+  return (
+    <PageShell width="full">
+      <PageHeader
+        title="Athlete App"
+        description="Daily athlete workspace for coach-assigned work, training logs, wellness notes, and completion records."
+        actions={
+          <TextInput
+            type="date"
+            value={date}
+            onChange={(event) => setDate(event.currentTarget.value)}
+          />
+        }
+      />
+
+      <SimpleGrid cols={{ base: 1, md: 2, xl: 4 }} spacing="md">
+        <MetricCard icon={CalendarCheck} color="checklist" label="Coach Set" value={assignedWork.length} detail="Open assigned items" />
+        <MetricCard icon={Checks} color="knowmore" label="Completed" value={summary.completed} detail={`${summary.totalLogs} records today`} />
+        <MetricCard icon={Activity} color="tactical" label="Minutes" value={summary.totalMinutes} detail="Recorded training time" />
+        <MetricCard icon={Heartbeat} color="review" label="Readiness" value={summary.averageReadiness ?? "—"} detail={`Intensity ${summary.averageIntensity ?? "—"}`} />
+      </SimpleGrid>
+
+      <SimpleGrid cols={{ base: 1, xl: 2 }} spacing="lg">
+        <UnifiedCard tone="checklist">
+          <UnifiedCardHeader title="Coach Assigned Today" supporting={<Badge variant="light" color="checklist">{assignedWork.length} items</Badge>} />
+          <UnifiedCardBody>
+            {assignedWork.length === 0 ? (
+              <Notice title="No assigned work">
+                Nothing is currently set for this athlete day. Record independent training or wellness notes below.
+              </Notice>
+            ) : (
+              <Stack gap="md">
+                {assignedWork.map((work) => (
+                  <Stack key={work.id} gap="xs">
+                    <Group justify="space-between" align="flex-start">
+                      <Stack gap={2} style={{ flex: 1 }}>
+                        <Group gap="xs">
+                          <Badge variant="outline" color="gray">#{work.publicId ?? "—"}</Badge>
+                          <Badge variant="light" color="checklist">{work.kanbanColumn}</Badge>
+                          <Badge variant="light" color="review">ICE {Math.round(work.iceScore)}</Badge>
+                        </Group>
+                        <BodyText>{work.title}</BodyText>
+                        {work.description ? <MetaText lineClamp={2}>{work.description}</MetaText> : null}
+                      </Stack>
+                      <Button
+                        size="xs"
+                        color="checklist"
+                        leftSection={<UserCheck size={14} />}
+                        loading={saving}
+                        onClick={() => void recordActivity({ work, completed: true })}
+                      >
+                        Complete
+                      </Button>
+                    </Group>
+                  </Stack>
+                ))}
+              </Stack>
+            )}
+          </UnifiedCardBody>
+        </UnifiedCard>
+
+        <UnifiedCard tone="tactical">
+          <UnifiedCardHeader title="Record Activity" supporting={<Badge variant="light" color="tactical">{date}</Badge>} />
+          <UnifiedCardBody>
+            <SegmentedControl
+              value={activityType}
+              data={ATHLETE_ACTIVITY_TYPES.map((item) => ({ value: item.value, label: item.label }))}
+              onChange={(value) => setActivityType(value as AthleteActivityType)}
+            />
+            <TextInput
+              label="What did you do?"
+              placeholder="Strength session, recovery walk, nutrition note..."
+              value={title}
+              onChange={(event) => setTitle(event.currentTarget.value)}
+            />
+            <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+              <NumberInput label="Minutes" min={1} max={1440} value={durationMinutes} onChange={(value) => setDurationMinutes(typeof value === "number" ? value : "")} />
+              <NumberInput label="Intensity" min={1} max={10} value={intensity} onChange={(value) => setIntensity(typeof value === "number" ? value : "")} />
+              <NumberInput label="Readiness" min={1} max={10} value={readiness} onChange={(value) => setReadiness(typeof value === "number" ? value : "")} />
+            </SimpleGrid>
+            <Textarea
+              label="Notes"
+              placeholder="Pain, energy, RPE, sets/reps, food, sleep, coach feedback..."
+              minRows={4}
+              autosize
+              value={notes}
+              onChange={(event) => setNotes(event.currentTarget.value)}
+            />
+            <Group gap="sm">
+              <Button leftSection={<Run size={16} />} loading={saving} onClick={() => void recordActivity()}>
+                Record
+              </Button>
+              <Button variant="light" color="review" onClick={resetForm}>
+                Clear
+              </Button>
+            </Group>
+          </UnifiedCardBody>
+        </UnifiedCard>
+      </SimpleGrid>
+
+      <UnifiedCard tone="review">
+        <UnifiedCardHeader title="Daily Record" supporting={<Badge variant="light" color="review">{logs.length} entries</Badge>} />
+        <UnifiedCardBody>
+          <Table highlightOnHover>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Activity</Table.Th>
+                <Table.Th>Type</Table.Th>
+                <Table.Th>Minutes</Table.Th>
+                <Table.Th>Intensity</Table.Th>
+                <Table.Th>Readiness</Table.Th>
+                <Table.Th>Status</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {logs.map((log) => (
+                <Table.Tr key={log.id}>
+                  <Table.Td>
+                    <Stack gap={2}>
+                      <BodyText>{log.title}</BodyText>
+                      {log.notes ? <MetaText lineClamp={1}>{log.notes}</MetaText> : null}
+                    </Stack>
+                  </Table.Td>
+                  <Table.Td>{log.activityType}</Table.Td>
+                  <Table.Td>{log.durationMinutes ?? "—"}</Table.Td>
+                  <Table.Td>{log.intensity ?? "—"}</Table.Td>
+                  <Table.Td>{log.readiness ?? "—"}</Table.Td>
+                  <Table.Td>
+                    <Badge variant="light" color={log.completionState === "COMPLETED" ? "knowmore" : "gray"}>
+                      {log.completionState}
+                    </Badge>
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </UnifiedCardBody>
+      </UnifiedCard>
+    </PageShell>
+  );
+}

--- a/src/app/[companyId]/athlete/page.tsx
+++ b/src/app/[companyId]/athlete/page.tsx
@@ -50,6 +50,16 @@ type AthleteLog = {
   completionState: string;
   createdAt: string;
   nbaItemId?: string | null;
+  metrics?: {
+    sleepHours?: number;
+    soreness?: number;
+    stress?: number;
+    mood?: number;
+    hydration?: number;
+    bodyWeight?: number;
+    painArea?: string;
+    nutritionNote?: string;
+  } | null;
 };
 
 type AthletePayload = {
@@ -66,6 +76,9 @@ type AthletePayload = {
     totalMinutes: number;
     averageReadiness: number | null;
     averageIntensity: number | null;
+    averageSleepHours: number | null;
+    averageSoreness: number | null;
+    painReports: number;
   };
 };
 
@@ -84,6 +97,14 @@ export default function AthletePage() {
   const [durationMinutes, setDurationMinutes] = useState<number | "">(45);
   const [intensity, setIntensity] = useState<number | "">(6);
   const [readiness, setReadiness] = useState<number | "">(7);
+  const [sleepHours, setSleepHours] = useState<number | "">(8);
+  const [soreness, setSoreness] = useState<number | "">(3);
+  const [stress, setStress] = useState<number | "">(3);
+  const [mood, setMood] = useState<number | "">(7);
+  const [hydration, setHydration] = useState<number | "">(7);
+  const [bodyWeight, setBodyWeight] = useState<number | "">("");
+  const [painArea, setPainArea] = useState("");
+  const [nutritionNote, setNutritionNote] = useState("");
 
   const loadDay = useCallback(async () => {
     setLoading(true);
@@ -108,6 +129,14 @@ export default function AthletePage() {
     setDurationMinutes(45);
     setIntensity(6);
     setReadiness(7);
+    setSleepHours(8);
+    setSoreness(3);
+    setStress(3);
+    setMood(7);
+    setHydration(7);
+    setBodyWeight("");
+    setPainArea("");
+    setNutritionNote("");
     setActivityType("TRAINING");
   };
 
@@ -130,6 +159,16 @@ export default function AthletePage() {
           durationMinutes,
           intensity,
           readiness,
+          metrics: {
+            sleepHours,
+            soreness,
+            stress,
+            mood,
+            hydration,
+            bodyWeight,
+            painArea,
+            nutritionNote,
+          },
           nbaItemId: work?.id,
           completionState: options?.completed ? "COMPLETED" : "RECORDED",
         }),
@@ -139,7 +178,7 @@ export default function AthletePage() {
     } finally {
       setSaving(false);
     }
-  }, [activityType, companyId, date, durationMinutes, intensity, loadDay, notes, readiness, title]);
+  }, [activityType, bodyWeight, companyId, date, durationMinutes, hydration, intensity, loadDay, mood, notes, nutritionNote, painArea, readiness, sleepHours, soreness, stress, title]);
 
   if (loading) {
     return (
@@ -157,6 +196,9 @@ export default function AthletePage() {
     totalMinutes: 0,
     averageReadiness: null,
     averageIntensity: null,
+    averageSleepHours: null,
+    averageSoreness: null,
+    painReports: 0,
   };
   const assignedWork = data?.assignedWork || [];
   const logs = data?.logs || [];
@@ -179,7 +221,7 @@ export default function AthletePage() {
         <MetricCard icon={CalendarCheck} color="checklist" label="Coach Set" value={assignedWork.length} detail="Open assigned items" />
         <MetricCard icon={Checks} color="knowmore" label="Completed" value={summary.completed} detail={`${summary.totalLogs} records today`} />
         <MetricCard icon={Activity} color="tactical" label="Minutes" value={summary.totalMinutes} detail="Recorded training time" />
-        <MetricCard icon={Heartbeat} color="review" label="Readiness" value={summary.averageReadiness ?? "—"} detail={`Intensity ${summary.averageIntensity ?? "—"}`} />
+        <MetricCard icon={Heartbeat} color="review" label="Readiness" value={summary.averageReadiness ?? "—"} detail={`Sleep ${summary.averageSleepHours ?? "—"}h · soreness ${summary.averageSoreness ?? "—"}`} />
       </SimpleGrid>
 
       <SimpleGrid cols={{ base: 1, xl: 2 }} spacing="lg">
@@ -240,6 +282,30 @@ export default function AthletePage() {
               <NumberInput label="Intensity" min={1} max={10} value={intensity} onChange={(value) => setIntensity(typeof value === "number" ? value : "")} />
               <NumberInput label="Readiness" min={1} max={10} value={readiness} onChange={(value) => setReadiness(typeof value === "number" ? value : "")} />
             </SimpleGrid>
+            <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+              <NumberInput label="Sleep hours" min={0} max={24} decimalScale={1} value={sleepHours} onChange={(value) => setSleepHours(typeof value === "number" ? value : "")} />
+              <NumberInput label="Soreness" min={1} max={10} value={soreness} onChange={(value) => setSoreness(typeof value === "number" ? value : "")} />
+              <NumberInput label="Stress" min={1} max={10} value={stress} onChange={(value) => setStress(typeof value === "number" ? value : "")} />
+            </SimpleGrid>
+            <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+              <NumberInput label="Mood" min={1} max={10} value={mood} onChange={(value) => setMood(typeof value === "number" ? value : "")} />
+              <NumberInput label="Hydration" min={1} max={10} value={hydration} onChange={(value) => setHydration(typeof value === "number" ? value : "")} />
+              <NumberInput label="Body weight" min={20} max={400} decimalScale={1} value={bodyWeight} onChange={(value) => setBodyWeight(typeof value === "number" ? value : "")} />
+            </SimpleGrid>
+            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
+              <TextInput
+                label="Pain area"
+                placeholder="None, left knee, shoulder..."
+                value={painArea}
+                onChange={(event) => setPainArea(event.currentTarget.value)}
+              />
+              <TextInput
+                label="Nutrition note"
+                placeholder="Meals, supplements, hydration..."
+                value={nutritionNote}
+                onChange={(event) => setNutritionNote(event.currentTarget.value)}
+              />
+            </SimpleGrid>
             <Textarea
               label="Notes"
               placeholder="Pain, energy, RPE, sets/reps, food, sleep, coach feedback..."
@@ -271,6 +337,7 @@ export default function AthletePage() {
                 <Table.Th>Minutes</Table.Th>
                 <Table.Th>Intensity</Table.Th>
                 <Table.Th>Readiness</Table.Th>
+                <Table.Th>Wellness</Table.Th>
                 <Table.Th>Status</Table.Th>
               </Table.Tr>
             </Table.Thead>
@@ -287,6 +354,12 @@ export default function AthletePage() {
                   <Table.Td>{log.durationMinutes ?? "—"}</Table.Td>
                   <Table.Td>{log.intensity ?? "—"}</Table.Td>
                   <Table.Td>{log.readiness ?? "—"}</Table.Td>
+                  <Table.Td>
+                    <MetaText>
+                      Sleep {log.metrics?.sleepHours ?? "—"}h · sore {log.metrics?.soreness ?? "—"}
+                      {log.metrics?.painArea ? ` · pain ${log.metrics.painArea}` : ""}
+                    </MetaText>
+                  </Table.Td>
                   <Table.Td>
                     <Badge variant="light" color={log.completionState === "COMPLETED" ? "knowmore" : "gray"}>
                       {log.completionState}

--- a/src/app/[companyId]/athletes/page.tsx
+++ b/src/app/[companyId]/athletes/page.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import {
+  Badge,
+  Group,
+  Loader,
+  SimpleGrid,
+  Stack,
+  Table,
+  TextInput,
+} from "@mantine/core";
+import {
+  IconAlertTriangle as AlertTriangle,
+  IconClipboardCheck as ClipboardCheck,
+  IconRun as Run,
+  IconUsers as Users,
+} from "@tabler/icons-react";
+import { MetricCard, Notice, PageHeader, PageShell } from "@/components/ui/app-shell";
+import { BodyText, MetaText } from "@/components/ui/typography";
+import { UnifiedCard, UnifiedCardBody, UnifiedCardHeader } from "@/components/ui/unified-card";
+
+type AthleteMetrics = {
+  sleepHours?: number;
+  soreness?: number;
+  stress?: number;
+  mood?: number;
+  hydration?: number;
+  bodyWeight?: number;
+  painArea?: string;
+  nutritionNote?: string;
+};
+
+type AthleteLog = {
+  id: string;
+  athleteEmail: string;
+  athleteName?: string | null;
+  activityType: string;
+  title: string;
+  notes?: string | null;
+  durationMinutes?: number | null;
+  readiness?: number | null;
+  intensity?: number | null;
+  completionState: string;
+  metrics?: AthleteMetrics | null;
+  createdAt: string;
+};
+
+type AthleteSummary = {
+  athleteEmail: string;
+  athleteName?: string | null;
+  totalLogs: number;
+  completed: number;
+  totalMinutes: number;
+  averageReadiness: number | null;
+  averageIntensity: number | null;
+  averageSleepHours: number | null;
+  averageSoreness: number | null;
+  averageStress: number | null;
+  averageHydration: number | null;
+  painReports: number;
+};
+
+type TeamPayload = {
+  date: string;
+  scope: "team";
+  logs: AthleteLog[];
+  assignedWork: unknown[];
+  summary: {
+    totalLogs: number;
+    completed: number;
+    totalMinutes: number;
+    averageReadiness: number | null;
+    averageIntensity: number | null;
+    averageSleepHours: number | null;
+    averageSoreness: number | null;
+    painReports: number;
+  };
+  athleteSummaries: AthleteSummary[];
+  error?: string;
+};
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+export default function AthletesPage() {
+  const params = useParams();
+  const companyId = params.companyId as string;
+  const [date, setDate] = useState(today());
+  const [data, setData] = useState<TeamPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadDay = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/athlete?companyId=${companyId}&date=${date}&scope=team`);
+      setData(await response.json());
+    } finally {
+      setLoading(false);
+    }
+  }, [companyId, date]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void loadDay();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [loadDay]);
+
+  if (loading) {
+    return (
+      <PageShell width="full">
+        <Stack align="center" py="xl">
+          <Loader />
+        </Stack>
+      </PageShell>
+    );
+  }
+
+  const summary = data?.summary || {
+    totalLogs: 0,
+    completed: 0,
+    totalMinutes: 0,
+    averageReadiness: null,
+    averageIntensity: null,
+    averageSleepHours: null,
+    averageSoreness: null,
+    painReports: 0,
+  };
+  const athleteSummaries = data?.athleteSummaries || [];
+  const logs = data?.logs || [];
+
+  return (
+    <PageShell width="full">
+      <PageHeader
+        title="Athlete Records"
+        description="Coach view of athlete daily records, completion evidence, readiness, wellness, and pain flags."
+        actions={
+          <TextInput
+            type="date"
+            value={date}
+            onChange={(event) => setDate(event.currentTarget.value)}
+          />
+        }
+      />
+
+      {data?.error ? (
+        <Notice title="Coach access required">{data.error}</Notice>
+      ) : null}
+
+      <SimpleGrid cols={{ base: 1, md: 2, xl: 4 }} spacing="md">
+        <MetricCard icon={Users} color="checklist" label="Athletes" value={athleteSummaries.length} detail="Reported today" />
+        <MetricCard icon={ClipboardCheck} color="knowmore" label="Completed" value={summary.completed} detail={`${summary.totalLogs} records logged`} />
+        <MetricCard icon={Run} color="tactical" label="Minutes" value={summary.totalMinutes} detail="Team recorded load" />
+        <MetricCard icon={AlertTriangle} color="review" label="Pain Flags" value={summary.painReports} detail={`Sleep ${summary.averageSleepHours ?? "—"}h · soreness ${summary.averageSoreness ?? "—"}`} />
+      </SimpleGrid>
+
+      <UnifiedCard tone="checklist">
+        <UnifiedCardHeader title="Athlete Daily Summary" supporting={<Badge variant="light" color="checklist">{athleteSummaries.length} athletes</Badge>} />
+        <UnifiedCardBody>
+          {athleteSummaries.length === 0 ? (
+            <Notice title="No athlete records">No athletes have recorded activity for this date yet.</Notice>
+          ) : (
+            <Table highlightOnHover>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Athlete</Table.Th>
+                  <Table.Th>Records</Table.Th>
+                  <Table.Th>Minutes</Table.Th>
+                  <Table.Th>Readiness</Table.Th>
+                  <Table.Th>Intensity</Table.Th>
+                  <Table.Th>Sleep</Table.Th>
+                  <Table.Th>Soreness</Table.Th>
+                  <Table.Th>Pain</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {athleteSummaries.map((athlete) => (
+                  <Table.Tr key={athlete.athleteEmail}>
+                    <Table.Td>
+                      <Stack gap={2}>
+                        <BodyText>{athlete.athleteName || athlete.athleteEmail}</BodyText>
+                        <MetaText>{athlete.athleteEmail}</MetaText>
+                      </Stack>
+                    </Table.Td>
+                    <Table.Td>{athlete.totalLogs}</Table.Td>
+                    <Table.Td>{athlete.totalMinutes}</Table.Td>
+                    <Table.Td>{athlete.averageReadiness ?? "—"}</Table.Td>
+                    <Table.Td>{athlete.averageIntensity ?? "—"}</Table.Td>
+                    <Table.Td>{athlete.averageSleepHours ?? "—"}</Table.Td>
+                    <Table.Td>{athlete.averageSoreness ?? "—"}</Table.Td>
+                    <Table.Td>
+                      <Badge variant="light" color={athlete.painReports ? "review" : "gray"}>
+                        {athlete.painReports}
+                      </Badge>
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          )}
+        </UnifiedCardBody>
+      </UnifiedCard>
+
+      <UnifiedCard tone="review">
+        <UnifiedCardHeader title="Recent Athlete Entries" supporting={<Badge variant="light" color="review">{logs.length} entries</Badge>} />
+        <UnifiedCardBody>
+          <Table highlightOnHover>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Athlete</Table.Th>
+                <Table.Th>Activity</Table.Th>
+                <Table.Th>Load</Table.Th>
+                <Table.Th>Wellness</Table.Th>
+                <Table.Th>Status</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {logs.map((log) => (
+                <Table.Tr key={log.id}>
+                  <Table.Td>
+                    <Stack gap={2}>
+                      <BodyText>{log.athleteName || log.athleteEmail}</BodyText>
+                      <MetaText>{log.athleteEmail}</MetaText>
+                    </Stack>
+                  </Table.Td>
+                  <Table.Td>
+                    <Stack gap={2}>
+                      <Group gap="xs">
+                        <Badge variant="outline" color="gray">{log.activityType}</Badge>
+                        <BodyText>{log.title}</BodyText>
+                      </Group>
+                      {log.notes ? <MetaText lineClamp={1}>{log.notes}</MetaText> : null}
+                    </Stack>
+                  </Table.Td>
+                  <Table.Td>
+                    <MetaText>{log.durationMinutes ?? "—"} min · intensity {log.intensity ?? "—"}</MetaText>
+                  </Table.Td>
+                  <Table.Td>
+                    <MetaText>
+                      Readiness {log.readiness ?? "—"} · sleep {log.metrics?.sleepHours ?? "—"}h · sore {log.metrics?.soreness ?? "—"}
+                    </MetaText>
+                    {log.metrics?.painArea ? <MetaText c="var(--mantine-color-review-4)">Pain: {log.metrics.painArea}</MetaText> : null}
+                  </Table.Td>
+                  <Table.Td>
+                    <Badge variant="light" color={log.completionState === "COMPLETED" ? "knowmore" : "gray"}>
+                      {log.completionState}
+                    </Badge>
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </UnifiedCardBody>
+      </UnifiedCard>
+    </PageShell>
+  );
+}

--- a/src/app/[companyId]/content-generation/page.tsx
+++ b/src/app/[companyId]/content-generation/page.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { Badge, Button, CopyButton, Group, Loader, SegmentedControl, SimpleGrid, Stack, Textarea } from "@mantine/core";
+import {
+  IconAd as Ad,
+  IconCopy as Copy,
+  IconMail as Mail,
+  IconRefresh as Refresh,
+  IconSparkles as Sparkles,
+  IconWorldWww as Landing,
+} from "@tabler/icons-react";
+import { MetricCard, Notice, PageHeader, PageShell } from "@/components/ui/app-shell";
+import { BodyText, MetaText } from "@/components/ui/typography";
+import { UnifiedCard, UnifiedCardBody, UnifiedCardHeader } from "@/components/ui/unified-card";
+import type { ContentTone, GeneratedContentBundle } from "@/lib/content-generation";
+
+type CreativeDraft = {
+  id: string;
+  title: string;
+  subject?: string | null;
+  content: string;
+  type: string;
+  createdAt: string;
+  usageMetrics?: any;
+};
+
+const toneOptions: Array<{ value: ContentTone; label: string }> = [
+  { value: "clear", label: "Clear" },
+  { value: "bold", label: "Bold" },
+  { value: "executive", label: "Executive" },
+  { value: "friendly", label: "Friendly" },
+  { value: "technical", label: "Technical" },
+];
+
+function CopyAction({ value }: { value: string }) {
+  return (
+    <CopyButton value={value}>
+      {({ copied, copy }) => (
+        <Button variant="subtle" size="xs" color={copied ? "knowmore" : "review"} leftSection={<Copy size={14} />} onClick={copy}>
+          {copied ? "Copied" : "Copy"}
+        </Button>
+      )}
+    </CopyButton>
+  );
+}
+
+function DraftCard({ draft }: { draft: CreativeDraft }) {
+  return (
+    <UnifiedCard tone={draft.type === "EMAIL" ? "knowmore" : draft.type === "LINKEDIN" ? "strategy" : "tactical"}>
+      <UnifiedCardHeader
+        title={draft.title}
+        supporting={
+          <Group gap="xs">
+            <Badge variant="outline" color="gray">{draft.type}</Badge>
+            {draft.usageMetrics?.platform ? <Badge variant="light" color="gray">{draft.usageMetrics.platform}</Badge> : null}
+          </Group>
+        }
+        actions={<CopyAction value={draft.subject ? `${draft.subject}\n\n${draft.content}` : draft.content} />}
+      />
+      <UnifiedCardBody>
+        {draft.subject ? <BodyText>{draft.subject}</BodyText> : null}
+        <BodyText>{draft.content}</BodyText>
+        <MetaText>{new Date(draft.createdAt).toLocaleString()}</MetaText>
+      </UnifiedCardBody>
+    </UnifiedCard>
+  );
+}
+
+export default function ContentGenerationPage() {
+  const params = useParams();
+  const companyId = params.companyId as string;
+  const [tone, setTone] = useState<ContentTone>("clear");
+  const [campaignBrief, setCampaignBrief] = useState("");
+  const [bundle, setBundle] = useState<GeneratedContentBundle | null>(null);
+  const [drafts, setDrafts] = useState<CreativeDraft[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [generating, setGenerating] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const loadDrafts = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/content-generation?companyId=${companyId}`);
+      const data = await response.json();
+      setDrafts(Array.isArray(data.drafts) ? data.drafts : []);
+    } finally {
+      setLoading(false);
+    }
+  }, [companyId]);
+
+  const generate = useCallback(async () => {
+    setGenerating(true);
+    setErrorMessage(null);
+    try {
+      const response = await fetch("/api/content-generation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ companyId, tone, campaignBrief }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        setErrorMessage(data.error || "Generation failed");
+        return;
+      }
+      setBundle(data.bundle);
+      setDrafts(Array.isArray(data.drafts) ? [...data.drafts, ...drafts] : drafts);
+    } finally {
+      setGenerating(false);
+    }
+  }, [campaignBrief, companyId, drafts, tone]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void loadDrafts();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [loadDrafts]);
+
+  if (loading) {
+    return (
+      <PageShell width="full">
+        <Stack align="center" py="xl">
+          <Loader />
+        </Stack>
+      </PageShell>
+    );
+  }
+
+  const emailCount = bundle?.emailSubjectLines.length ?? drafts.filter((draft) => draft.type === "EMAIL").length;
+  const adCount = bundle?.adCopy.length ?? drafts.filter((draft) => draft.type === "AD_COPY").length;
+  const socialCount = bundle?.socialPosts.length ?? drafts.filter((draft) => draft.title.toLowerCase().includes("social")).length;
+
+  return (
+    <PageShell width="full">
+      <PageHeader
+        title="Content Generation"
+        description="Generate evidence-aware email subject lines, platform ad copy, social posts, and landing-page sections from product and competitor context."
+        actions={
+          <Button leftSection={generating ? <Loader size={16} color="white" /> : <Sparkles size={16} />} onClick={() => void generate()}>
+            Generate
+          </Button>
+        }
+      />
+
+      <SimpleGrid cols={{ base: 1, md: 2, xl: 4 }} spacing="md">
+        <MetricCard icon={Mail} color="knowmore" label="Email Subjects" value={emailCount} detail="5 variants per run" />
+        <MetricCard icon={Ad} color="tactical" label="Ad Platforms" value={adCount} detail="Facebook, Google, LinkedIn" />
+        <MetricCard icon={Sparkles} color="strategy" label="Social Posts" value={socialCount} detail="Twitter, LinkedIn, Facebook" />
+        <MetricCard icon={Landing} color="review" label="Saved Drafts" value={drafts.length} detail="CreativeDraft records" />
+      </SimpleGrid>
+
+      {errorMessage ? (
+        <Notice title="Generation failed" variant="destructive">
+          {errorMessage}
+        </Notice>
+      ) : null}
+
+      <UnifiedCard tone="review">
+        <UnifiedCardHeader title="Generation Controls" />
+        <UnifiedCardBody>
+          <SegmentedControl
+            value={tone}
+            data={toneOptions}
+            onChange={(value) => setTone(value as ContentTone)}
+          />
+          <Textarea
+            label="Campaign brief"
+            placeholder="Example: launch a Q3 onboarding recovery campaign for enterprise prospects"
+            value={campaignBrief}
+            minRows={3}
+            autosize
+            onChange={(event) => setCampaignBrief(event.currentTarget.value)}
+          />
+          <Group gap="sm">
+            <Button leftSection={<Sparkles size={16} />} loading={generating} onClick={() => void generate()}>
+              Generate Content
+            </Button>
+            <Button variant="light" color="review" leftSection={<Refresh size={16} />} onClick={() => void loadDrafts()}>
+              Refresh Drafts
+            </Button>
+          </Group>
+        </UnifiedCardBody>
+      </UnifiedCard>
+
+      {bundle ? (
+        <SimpleGrid cols={{ base: 1, xl: 2 }} spacing="lg">
+          <UnifiedCard tone="knowmore">
+            <UnifiedCardHeader title="Email Subject Lines" supporting={<Badge variant="light" color="knowmore">5 variants</Badge>} />
+            <UnifiedCardBody>
+              {bundle.emailSubjectLines.map((subject) => (
+                <Group key={subject} justify="space-between" wrap="nowrap">
+                  <BodyText>{subject}</BodyText>
+                  <CopyAction value={subject} />
+                </Group>
+              ))}
+            </UnifiedCardBody>
+          </UnifiedCard>
+
+          <UnifiedCard tone="strategy">
+            <UnifiedCardHeader title="Landing Page Copy" />
+            <UnifiedCardBody>
+              <BodyText>{bundle.landingPage.heroHeadline}</BodyText>
+              <BodyText>{bundle.landingPage.heroSubheadline}</BodyText>
+              <Stack gap={4}>
+                {bundle.landingPage.benefits.map((benefit) => (
+                  <MetaText key={benefit}>{benefit}</MetaText>
+                ))}
+              </Stack>
+              <Badge variant="light" color="strategy">{bundle.landingPage.cta}</Badge>
+            </UnifiedCardBody>
+          </UnifiedCard>
+
+          {bundle.adCopy.map((item) => (
+            <UnifiedCard key={item.platform} tone="tactical">
+              <UnifiedCardHeader title={`${item.platform} Ad`} supporting={<Badge variant="outline" color="gray">{item.characterLimit}</Badge>} actions={<CopyAction value={`${item.headline}\n\n${item.primaryText}\n\n${item.cta}`} />} />
+              <UnifiedCardBody>
+                <BodyText>{item.headline}</BodyText>
+                <BodyText>{item.primaryText}</BodyText>
+                <Badge variant="light" color="tactical">{item.cta}</Badge>
+              </UnifiedCardBody>
+            </UnifiedCard>
+          ))}
+
+          {bundle.socialPosts.map((item) => (
+            <UnifiedCard key={item.platform} tone="review">
+              <UnifiedCardHeader title={`${item.platform} Post`} supporting={<Badge variant="outline" color="gray">{item.characterLimit}</Badge>} actions={<CopyAction value={item.post} />} />
+              <UnifiedCardBody>
+                <BodyText>{item.post}</BodyText>
+              </UnifiedCardBody>
+            </UnifiedCard>
+          ))}
+        </SimpleGrid>
+      ) : (
+        <Notice title="Ready to generate">
+          Pick a tone, add an optional campaign brief, and generate a full marketing copy set from the company context already in Data, Goals, Topics, and competitor records.
+        </Notice>
+      )}
+
+      <UnifiedCard tone="neutral">
+        <UnifiedCardHeader title="Recent Creative Drafts" supporting={<Badge variant="light" color="gray">{drafts.length} drafts</Badge>} />
+        <UnifiedCardBody>
+          <SimpleGrid cols={{ base: 1, md: 2, xl: 3 }} spacing="md">
+            {drafts.slice(0, 12).map((draft) => (
+              <DraftCard key={draft.id} draft={draft} />
+            ))}
+          </SimpleGrid>
+        </UnifiedCardBody>
+      </UnifiedCard>
+    </PageShell>
+  );
+}

--- a/src/app/[companyId]/evaluations/page.tsx
+++ b/src/app/[companyId]/evaluations/page.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { Badge, Button, Group, Loader, Progress, SimpleGrid, Stack, Table } from "@mantine/core";
+import {
+  IconAlertTriangle as AlertTriangle,
+  IconArrowUpRight as ArrowUpRight,
+  IconChecks as Checks,
+  IconFlask as Flask,
+  IconRefresh as Refresh,
+  IconShieldCheck as ShieldCheck,
+} from "@tabler/icons-react";
+import { MetricCard, Notice, PageHeader, PageShell } from "@/components/ui/app-shell";
+import { BodyText, MetaText } from "@/components/ui/typography";
+import { UnifiedCard, UnifiedCardBody, UnifiedCardHeader } from "@/components/ui/unified-card";
+
+function scorePercent(value?: number) {
+  return Math.round((value ?? 0) * 100);
+}
+
+function gateColor(status?: string) {
+  if (status === "PASS") return "green";
+  if (status === "ADVISORY") return "yellow";
+  if (status === "REVIEW_REQUIRED") return "orange";
+  return "red";
+}
+
+export default function EvaluationsPage() {
+  const params = useParams();
+  const companyId = params.companyId as string;
+  const [data, setData] = useState<any | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/evaluations?companyId=${companyId}`);
+      setData(await response.json());
+    } finally {
+      setLoading(false);
+    }
+  }, [companyId]);
+
+  const runBench = useCallback(async (persistObservability = false) => {
+    if (persistObservability) {
+      setPublishing(true);
+    } else {
+      setRunning(true);
+    }
+    try {
+      const response = await fetch("/api/evaluations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          companyId,
+          persistObservability,
+          candidate: {
+            label: "candidate-strict-gate",
+            evidenceStrictness: "strict",
+            confidencePolicy: "risk_averse",
+            actionabilityBoost: 8,
+          },
+        }),
+      });
+      setData(await response.json());
+    } finally {
+      setRunning(false);
+      setPublishing(false);
+    }
+  }, [companyId]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void loadData();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [loadData]);
+
+  if (loading) {
+    return (
+      <PageShell width="full">
+        <Stack align="center" py="xl">
+          <Loader />
+        </Stack>
+      </PageShell>
+    );
+  }
+
+  const comparison = data?.comparison;
+  const candidate = comparison?.candidate;
+  const baseline = comparison?.baseline;
+  const failedCases = candidate?.failedCases || [];
+
+  return (
+    <PageShell width="full">
+      <PageHeader
+        title="Evaluation Bench"
+        description="Synthetic replay and promotion gates for recommendation, grounded-answer, search, KPI, workflow, competitor, and data-readiness behavior."
+        actions={
+          <>
+            <Button
+              leftSection={<Refresh size={16} />}
+              variant="light"
+              color="review"
+              loading={running}
+              onClick={() => void runBench(false)}
+            >
+              Run Bench
+            </Button>
+            <Button
+              leftSection={<ArrowUpRight size={16} />}
+              variant="light"
+              color="strategy"
+              disabled={failedCases.length === 0}
+              loading={publishing}
+              onClick={() => void runBench(true)}
+            >
+              Publish Failures
+            </Button>
+          </>
+        }
+      />
+
+      <SimpleGrid cols={{ base: 1, md: 2, xl: 4 }} spacing="md">
+        <MetricCard icon={Flask} color="review" label="Candidate Score" value={`${scorePercent(candidate?.aggregateScore)}%`} detail={candidate?.label || "candidate"} />
+        <MetricCard icon={Checks} color="checklist" label="Pass Rate" value={`${scorePercent(candidate?.passRate)}%`} detail={`${candidate?.trends?.passedCases ?? 0}/${candidate?.trends?.totalCases ?? 0} cases`} />
+        <MetricCard icon={ShieldCheck} color="strategy" label="Promotion Gate" value={comparison?.promotionGate?.status || "UNKNOWN"} detail={comparison?.delta >= 0 ? `+${comparison.delta}` : comparison?.delta} />
+        <MetricCard icon={AlertTriangle} color="knowmore" label="High-Risk Fails" value={candidate?.trends?.highRiskFailures ?? 0} detail={`${failedCases.length} total failed`} />
+      </SimpleGrid>
+
+      {comparison?.promotionGate?.status !== "PASS" ? (
+        <Notice title="Promotion gate needs review" icon={AlertTriangle} variant="destructive">
+          {comparison?.promotionGate?.reason}
+        </Notice>
+      ) : null}
+
+      <SimpleGrid cols={{ base: 1, xl: 2 }} spacing="lg">
+        <UnifiedCard tone="review">
+          <UnifiedCardHeader
+            title="Current vs Candidate"
+            supporting={
+              <>
+                <Badge variant="light" color="gray">Baseline {scorePercent(baseline?.aggregateScore)}%</Badge>
+                <Badge variant="light" color={gateColor(candidate?.gateOutcome)}>Candidate {candidate?.gateOutcome}</Badge>
+              </>
+            }
+          />
+          <UnifiedCardBody>
+            <Stack gap="xs">
+              <Group justify="space-between">
+                <BodyText>Baseline quality</BodyText>
+                <MetaText>{scorePercent(baseline?.aggregateScore)}%</MetaText>
+              </Group>
+              <Progress value={scorePercent(baseline?.aggregateScore)} color="gray" />
+              <Group justify="space-between">
+                <BodyText>Candidate quality</BodyText>
+                <MetaText>{scorePercent(candidate?.aggregateScore)}%</MetaText>
+              </Group>
+              <Progress value={scorePercent(candidate?.aggregateScore)} color={gateColor(candidate?.gateOutcome)} />
+            </Stack>
+            <Table highlightOnHover>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Case</Table.Th>
+                  <Table.Th>Baseline</Table.Th>
+                  <Table.Th>Candidate</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {(comparison?.regressedCases || []).concat(comparison?.improvedCases || []).map((item: any) => (
+                  <Table.Tr key={item.caseId}>
+                    <Table.Td>{item.title}</Table.Td>
+                    <Table.Td>{scorePercent(item.baselineScore)}%</Table.Td>
+                    <Table.Td>{scorePercent(item.candidateScore)}%</Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </UnifiedCardBody>
+        </UnifiedCard>
+
+        <UnifiedCard tone="knowmore">
+          <UnifiedCardHeader title="Seeded Cases" supporting={<Badge variant="light" color="knowmore">{candidate?.cases?.length ?? 0} cases</Badge>} />
+          <UnifiedCardBody>
+            <Table highlightOnHover>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Case</Table.Th>
+                  <Table.Th>Kind</Table.Th>
+                  <Table.Th>Score</Table.Th>
+                  <Table.Th>Gate</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {(candidate?.cases || []).map((testCase: any) => (
+                  <Table.Tr key={testCase.caseId}>
+                    <Table.Td>{testCase.title}</Table.Td>
+                    <Table.Td>{testCase.kind}</Table.Td>
+                    <Table.Td>{scorePercent(testCase.score)}%</Table.Td>
+                    <Table.Td>
+                      <Badge variant="light" color={gateColor(testCase.gateOutcome)}>
+                        {testCase.gateOutcome}
+                      </Badge>
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </UnifiedCardBody>
+        </UnifiedCard>
+      </SimpleGrid>
+
+      <UnifiedCard tone="tactical">
+        <UnifiedCardHeader title="Failed Case Reasons" supporting={<Badge variant="light" color="tactical">{failedCases.length} failures</Badge>} />
+        <UnifiedCardBody>
+          <SimpleGrid cols={{ base: 1, lg: 2 }} spacing="md">
+            {failedCases.map((testCase: any) => (
+              <Stack key={testCase.caseId} gap="xs">
+                <Group gap="xs">
+                  <Badge variant="outline" color={gateColor(testCase.gateOutcome)}>{testCase.gateOutcome}</Badge>
+                  <MetaText>{scorePercent(testCase.score)}%</MetaText>
+                </Group>
+                <BodyText>{testCase.title}</BodyText>
+                <Stack gap={4}>
+                  {testCase.reasons.map((reason: string) => (
+                    <MetaText key={reason}>{reason}</MetaText>
+                  ))}
+                </Stack>
+              </Stack>
+            ))}
+          </SimpleGrid>
+        </UnifiedCardBody>
+      </UnifiedCard>
+    </PageShell>
+  );
+}

--- a/src/app/api/athlete/route.ts
+++ b/src/app/api/athlete/route.ts
@@ -4,9 +4,11 @@ import { recordInteractionEventFromRequest, recordOutcomeEvent } from "@/lib/aud
 import {
   clampAthleteScore,
   dayBounds,
+  normalizeAthleteMetrics,
   normalizeActivityType,
   normalizeDurationMinutes,
   summarizeAthleteDay,
+  summarizeAthleteTeam,
 } from "@/lib/athlete-activity";
 import { prisma } from "@/lib/db";
 import { verifyMembership } from "@/lib/permissions";
@@ -17,20 +19,52 @@ function normalizeText(value: unknown, fallback = "") {
   return typeof value === "string" && value.trim() ? value.trim() : fallback;
 }
 
-function parseMetrics(value: unknown): Prisma.InputJsonValue {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
-  return value as Prisma.InputJsonObject;
-}
-
 export async function GET(request: NextRequest) {
   const companyId = request.nextUrl.searchParams.get("companyId");
   const { safeDate, start, end } = dayBounds(request.nextUrl.searchParams.get("date"));
+  const scope = request.nextUrl.searchParams.get("scope");
   if (!companyId) {
     return NextResponse.json({ error: "companyId required" }, { status: 400 });
   }
 
-  const auth = await verifyMembership(request, companyId);
+  const auth = await verifyMembership(request, companyId, scope === "team" ? "ADMIN" : undefined);
   if (auth.error) return auth.error;
+
+  if (scope === "team") {
+    const [assignedWork, logs] = await Promise.all([
+      prisma.nBAItem.findMany({
+        where: {
+          companyId,
+          activityState: { in: ["ACTIVE", "STALE"] },
+          processingStatus: { in: ["DRAFT", "CHECKED", "VERIFIED", "ACCEPTED", "REVIEW"] },
+          kanbanColumn: { in: ["TODO", "CHECKLIST"] },
+          OR: [
+            { scheduledDate: null },
+            { scheduledDate: { lte: end } },
+          ],
+        },
+        orderBy: [{ scheduledDate: "asc" }, { sortOrder: "asc" }, { iceScore: "desc" }],
+        take: 50,
+      }),
+      prisma.athleteActivityLog.findMany({
+        where: {
+          companyId,
+          activityDate: { gte: start, lte: end },
+        },
+        orderBy: [{ createdAt: "desc" }],
+        take: 200,
+      }),
+    ]);
+
+    return NextResponse.json({
+      date: safeDate,
+      scope: "team",
+      assignedWork,
+      logs,
+      summary: summarizeAthleteDay(logs),
+      athleteSummaries: summarizeAthleteTeam(logs),
+    });
+  }
 
   const athleteEmail = auth.session.email.trim().toLowerCase();
   const [assignedWork, logs] = await Promise.all([
@@ -105,7 +139,7 @@ export async function POST(request: NextRequest) {
         intensity: clampAthleteScore(data.intensity),
         readiness: clampAthleteScore(data.readiness),
         completionState,
-        metrics: parseMetrics(data.metrics),
+        metrics: normalizeAthleteMetrics(data.metrics) as Prisma.InputJsonValue,
       },
     });
 
@@ -149,6 +183,7 @@ export async function POST(request: NextRequest) {
         durationMinutes: created.durationMinutes,
         intensity: created.intensity,
         readiness: created.readiness,
+        metrics: created.metrics,
       },
       teachingWeight: completionState === "COMPLETED" ? 80 : 45,
     });

--- a/src/app/api/athlete/route.ts
+++ b/src/app/api/athlete/route.ts
@@ -1,0 +1,161 @@
+import { Prisma } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
+import { recordInteractionEventFromRequest, recordOutcomeEvent } from "@/lib/audit-ledger";
+import {
+  clampAthleteScore,
+  dayBounds,
+  normalizeActivityType,
+  normalizeDurationMinutes,
+  summarizeAthleteDay,
+} from "@/lib/athlete-activity";
+import { prisma } from "@/lib/db";
+import { verifyMembership } from "@/lib/permissions";
+
+export const dynamic = "force-dynamic";
+
+function normalizeText(value: unknown, fallback = "") {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function parseMetrics(value: unknown): Prisma.InputJsonValue {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Prisma.InputJsonObject;
+}
+
+export async function GET(request: NextRequest) {
+  const companyId = request.nextUrl.searchParams.get("companyId");
+  const { safeDate, start, end } = dayBounds(request.nextUrl.searchParams.get("date"));
+  if (!companyId) {
+    return NextResponse.json({ error: "companyId required" }, { status: 400 });
+  }
+
+  const auth = await verifyMembership(request, companyId);
+  if (auth.error) return auth.error;
+
+  const athleteEmail = auth.session.email.trim().toLowerCase();
+  const [assignedWork, logs] = await Promise.all([
+    prisma.nBAItem.findMany({
+      where: {
+        companyId,
+        activityState: { in: ["ACTIVE", "STALE"] },
+        processingStatus: { in: ["DRAFT", "CHECKED", "VERIFIED", "ACCEPTED", "REVIEW"] },
+        kanbanColumn: { in: ["TODO", "CHECKLIST"] },
+        OR: [
+          { scheduledDate: null },
+          { scheduledDate: { lte: end } },
+        ],
+      },
+      orderBy: [{ scheduledDate: "asc" }, { sortOrder: "asc" }, { iceScore: "desc" }],
+      take: 24,
+    }),
+    prisma.athleteActivityLog.findMany({
+      where: {
+        companyId,
+        athleteEmail,
+        activityDate: { gte: start, lte: end },
+      },
+      orderBy: [{ createdAt: "desc" }],
+    }),
+  ]);
+
+  return NextResponse.json({
+    date: safeDate,
+    athlete: {
+      email: athleteEmail,
+      name: auth.session.name,
+    },
+    assignedWork,
+    logs,
+    summary: summarizeAthleteDay(logs),
+  });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const data = await request.json();
+    const companyId = normalizeText(data.companyId);
+    if (!companyId) {
+      return NextResponse.json({ error: "companyId required" }, { status: 400 });
+    }
+
+    const auth = await verifyMembership(request, companyId);
+    if (auth.error) return auth.error;
+
+    const title = normalizeText(data.title);
+    if (!title) {
+      return NextResponse.json({ error: "title required" }, { status: 400 });
+    }
+
+    const { start } = dayBounds(typeof data.activityDate === "string" ? data.activityDate : null);
+    const athleteEmail = auth.session.email.trim().toLowerCase();
+    const nbaItemId = normalizeText(data.nbaItemId) || undefined;
+    const completionState = data.completionState === "COMPLETED" ? "COMPLETED" : "RECORDED";
+
+    const created = await prisma.athleteActivityLog.create({
+      data: {
+        companyId,
+        athleteEmail,
+        athleteName: auth.session.name,
+        nbaItemId,
+        activityDate: start,
+        activityType: normalizeActivityType(data.activityType),
+        title,
+        notes: normalizeText(data.notes) || undefined,
+        durationMinutes: normalizeDurationMinutes(data.durationMinutes),
+        intensity: clampAthleteScore(data.intensity),
+        readiness: clampAthleteScore(data.readiness),
+        completionState,
+        metrics: parseMetrics(data.metrics),
+      },
+    });
+
+    if (completionState === "COMPLETED" && nbaItemId) {
+      await prisma.nBAItem.updateMany({
+        where: {
+          id: nbaItemId,
+          companyId,
+        },
+        data: {
+          processingStatus: "ACCEPTED",
+          status: "COMPLETED",
+          activityState: "ARCHIVED",
+          userAnnotation: normalizeText(data.notes, "Completed from athlete app"),
+        },
+      });
+    }
+
+    await recordInteractionEventFromRequest(request, {
+      companyId,
+      surface: "athlete-app",
+      interactionType: completionState === "COMPLETED" ? "ATHLETE_WORK_COMPLETED" : "ATHLETE_ACTIVITY_RECORDED",
+      entityType: nbaItemId ? "TASK" : "ATHLETE_ACTIVITY",
+      entityId: nbaItemId || created.id,
+      afterState: created,
+      teachingWeight: completionState === "COMPLETED" ? 80 : 45,
+    });
+
+    await recordOutcomeEvent({
+      companyId,
+      actorType: "ATHLETE",
+      actorEmail: athleteEmail,
+      entityType: nbaItemId ? "TASK" : "ATHLETE_ACTIVITY",
+      entityId: nbaItemId || created.id,
+      outcomeType: completionState === "COMPLETED" ? "ATHLETE_COMPLETED_ASSIGNED_WORK" : "ATHLETE_RECORDED_ACTIVITY",
+      outcomeValue: completionState,
+      annotation: created.notes ?? undefined,
+      payload: {
+        activityLogId: created.id,
+        activityType: created.activityType,
+        durationMinutes: created.durationMinutes,
+        intensity: created.intensity,
+        readiness: created.readiness,
+      },
+      teachingWeight: completionState === "COMPLETED" ? 80 : 45,
+    });
+
+    return NextResponse.json(created);
+  } catch (error) {
+    console.error("[API:Athlete] failure:", error);
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}

--- a/src/app/api/companies/[companyId]/dashboard/route.ts
+++ b/src/app/api/companies/[companyId]/dashboard/route.ts
@@ -79,6 +79,12 @@ export async function GET(
             queueColumn: { not: "PARKED" },
           },
         }),
+        prisma.creativeDraft.count({
+          where: {
+            companyId: cid,
+            status: { in: ["DRAFT", "APPROVED"] },
+          },
+        }),
       ]).then(([
         sourceCount,
         fileCount,
@@ -89,6 +95,7 @@ export async function GET(
         checklistCount,
         reviewCount,
         pipelineJobCount,
+        creativeDraftCount,
       ]) => ({
         sources: sourceCount + fileCount,
         files: fileCount,
@@ -99,6 +106,7 @@ export async function GET(
         checklistCount,
         reviewCount,
         pipelineJobs: pipelineJobCount,
+        creativeDrafts: creativeDraftCount,
       })),
     ]);
 
@@ -127,6 +135,7 @@ export async function GET(
       checklistCount: Math.max(snapshot?.checklistCount ?? 0, liveCounts.checklistCount, topTasks.length),
       reviewCount: Math.max(snapshot?.reviewGatewayCount ?? 0, liveCounts.reviewCount),
       pipelineJobs: liveCounts.pipelineJobs,
+      creativeDrafts: liveCounts.creativeDrafts,
     };
 
     return NextResponse.json({

--- a/src/app/api/companies/[companyId]/dashboard/route.ts
+++ b/src/app/api/companies/[companyId]/dashboard/route.ts
@@ -85,6 +85,11 @@ export async function GET(
             status: { in: ["DRAFT", "APPROVED"] },
           },
         }),
+        prisma.athleteActivityLog.count({
+          where: {
+            companyId: cid,
+          },
+        }),
       ]).then(([
         sourceCount,
         fileCount,
@@ -96,6 +101,7 @@ export async function GET(
         reviewCount,
         pipelineJobCount,
         creativeDraftCount,
+        athleteActivityLogCount,
       ]) => ({
         sources: sourceCount + fileCount,
         files: fileCount,
@@ -107,6 +113,7 @@ export async function GET(
         reviewCount,
         pipelineJobs: pipelineJobCount,
         creativeDrafts: creativeDraftCount,
+        athleteActivityLogs: athleteActivityLogCount,
       })),
     ]);
 
@@ -136,6 +143,7 @@ export async function GET(
       reviewCount: Math.max(snapshot?.reviewGatewayCount ?? 0, liveCounts.reviewCount),
       pipelineJobs: liveCounts.pipelineJobs,
       creativeDrafts: liveCounts.creativeDrafts,
+      athleteActivityLogs: liveCounts.athleteActivityLogs,
     };
 
     return NextResponse.json({

--- a/src/app/api/content-generation/route.ts
+++ b/src/app/api/content-generation/route.ts
@@ -1,0 +1,221 @@
+import { CreativeDraftType } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
+import { recordGenerationEvent, recordInteractionEventFromRequest } from "@/lib/audit-ledger";
+import { generateContentBundle, serializeContentSection, type ContentTone } from "@/lib/content-generation";
+import { prisma } from "@/lib/db";
+import { verifyMembership } from "@/lib/permissions";
+import { APP_VERSION, BRAIN_VERSION } from "@/lib/release";
+
+export const dynamic = "force-dynamic";
+
+const VALID_TONES = new Set<ContentTone>(["clear", "bold", "executive", "friendly", "technical"]);
+
+function normalizeTone(value: unknown): ContentTone {
+  return typeof value === "string" && VALID_TONES.has(value as ContentTone) ? value as ContentTone : "clear";
+}
+
+function compactContext(items: Array<{ title?: string | null; body?: string | null; content?: string | null; description?: string | null; entityTag?: string | null }>, limit: number) {
+  return items
+    .map((item) => [item.title, item.entityTag, item.description, item.body, item.content].filter(Boolean).join(": "))
+    .map((value) => value.replace(/\s+/g, " ").trim())
+    .filter(Boolean)
+    .slice(0, limit);
+}
+
+function draftPayloads(companyId: string, bundle: ReturnType<typeof generateContentBundle>) {
+  const emailDrafts = bundle.emailSubjectLines.map((subject, index) => ({
+    companyId,
+    type: CreativeDraftType.EMAIL,
+    title: `Email subject ${index + 1}`,
+    subject,
+    content: subject,
+    usageMetrics: {
+      platform: "Email",
+      characterLimit: 72,
+      tone: bundle.tone,
+      generatedBy: "content-generation",
+    },
+    appVersion: APP_VERSION,
+    brainVersion: BRAIN_VERSION,
+    promptVersion: `content-generation@${APP_VERSION}`,
+  }));
+
+  const adDrafts = bundle.adCopy.map((item) => ({
+    companyId,
+    type: CreativeDraftType.AD_COPY,
+    title: `${item.platform} ad copy`,
+    subject: item.headline,
+    content: serializeContentSection(`${item.platform} Ad`, item),
+    usageMetrics: {
+      platform: item.platform,
+      characterLimit: item.characterLimit,
+      tone: bundle.tone,
+      generatedBy: "content-generation",
+    },
+    appVersion: APP_VERSION,
+    brainVersion: BRAIN_VERSION,
+    promptVersion: `content-generation@${APP_VERSION}`,
+  }));
+
+  const socialDrafts = bundle.socialPosts.map((item) => ({
+    companyId,
+    type: item.platform === "LinkedIn" ? CreativeDraftType.LINKEDIN : CreativeDraftType.AD_COPY,
+    title: `${item.platform} social post`,
+    subject: item.platform,
+    content: item.post,
+    usageMetrics: {
+      platform: item.platform,
+      characterLimit: item.characterLimit,
+      tone: bundle.tone,
+      generatedBy: "content-generation",
+    },
+    appVersion: APP_VERSION,
+    brainVersion: BRAIN_VERSION,
+    promptVersion: `content-generation@${APP_VERSION}`,
+  }));
+
+  const landingDraft = {
+    companyId,
+    type: CreativeDraftType.AD_COPY,
+    title: "Landing page copy",
+    subject: bundle.landingPage.heroHeadline,
+    content: serializeContentSection("Landing Page", bundle.landingPage),
+    usageMetrics: {
+      platform: "Landing Page",
+      tone: bundle.tone,
+      generatedBy: "content-generation",
+    },
+    appVersion: APP_VERSION,
+    brainVersion: BRAIN_VERSION,
+    promptVersion: `content-generation@${APP_VERSION}`,
+  };
+
+  return [...emailDrafts, ...adDrafts, ...socialDrafts, landingDraft];
+}
+
+export async function GET(request: NextRequest) {
+  const companyId = request.nextUrl.searchParams.get("companyId");
+  if (!companyId) {
+    return NextResponse.json({ error: "companyId required" }, { status: 400 });
+  }
+
+  const auth = await verifyMembership(request, companyId);
+  if (auth.error) return auth.error;
+
+  const drafts = await prisma.creativeDraft.findMany({
+    where: { companyId },
+    orderBy: [{ createdAt: "desc" }],
+    take: 30,
+  });
+
+  return NextResponse.json({ drafts });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const data = await request.json();
+    const companyId = String(data.companyId || "");
+    if (!companyId) {
+      return NextResponse.json({ error: "companyId required" }, { status: 400 });
+    }
+
+    const auth = await verifyMembership(request, companyId);
+    if (auth.error) return auth.error;
+
+    const tone = normalizeTone(data.tone);
+    const campaignBrief = typeof data.campaignBrief === "string" ? data.campaignBrief.trim() : "";
+    const [company, productSources, competitorSources, goals, topics, tasks] = await Promise.all([
+      prisma.company.findUnique({ where: { id: companyId } }),
+      prisma.source.findMany({
+        where: { companyId, intelligenceType: "INTERNAL" },
+        orderBy: [{ iceScore: "desc" }, { updatedAt: "desc" }],
+        take: 8,
+      }),
+      prisma.source.findMany({
+        where: { companyId, intelligenceType: "COMPETITOR" },
+        orderBy: [{ iceScore: "desc" }, { updatedAt: "desc" }],
+        take: 6,
+      }),
+      prisma.goalcard.findMany({
+        where: { companyId, activityState: { in: ["ACTIVE", "STALE"] } },
+        orderBy: [{ iceScore: "desc" }, { updatedAt: "desc" }],
+        take: 5,
+      }),
+      prisma.topic.findMany({
+        where: { companyId, active: true },
+        orderBy: [{ iceScore: "desc" }, { updatedAt: "desc" }],
+        take: 5,
+      }),
+      prisma.nBAItem.findMany({
+        where: { companyId, activityState: { in: ["ACTIVE", "STALE"] } },
+        orderBy: [{ iceScore: "desc" }, { updatedAt: "desc" }],
+        take: 5,
+      }),
+    ]);
+
+    if (!company) {
+      return NextResponse.json({ error: "Company not found" }, { status: 404 });
+    }
+
+    const bundle = generateContentBundle({
+      companyName: company.name,
+      industry: company.industry,
+      description: company.description,
+      targetMarket: company.targetMarket,
+      tone,
+      campaignBrief,
+      productContext: compactContext([
+        ...productSources,
+        ...topics.map((topic) => ({ title: topic.label, body: topic.notes })),
+      ], 8),
+      competitorContext: compactContext(competitorSources, 6),
+      goalContext: compactContext([
+        ...goals,
+        ...tasks.map((task) => ({ title: task.title, description: task.description })),
+      ], 8),
+    });
+
+    const createdDrafts = await prisma.$transaction(
+      draftPayloads(companyId, bundle).map((payload) => prisma.creativeDraft.create({ data: payload })),
+    );
+
+    await recordInteractionEventFromRequest(request, {
+      companyId,
+      surface: "content-generation",
+      interactionType: "CONTENT_GENERATION_RUN",
+      entityType: "CREATIVE_DRAFT_BUNDLE",
+      entityId: companyId,
+      payload: {
+        tone,
+        campaignBrief,
+        draftCount: createdDrafts.length,
+      },
+      teachingWeight: 55,
+    });
+
+    await recordGenerationEvent({
+      companyId,
+      entityType: "CREATIVE_DRAFT_BUNDLE",
+      entityId: companyId,
+      promptName: "content-generation",
+      promptVersion: `content-generation@${APP_VERSION}`,
+      modelName: "local-deterministic-template",
+      inputSummary: campaignBrief || "Generated from product, competitor, goal, and topic context.",
+      generatedTitle: "Marketing content bundle",
+      generatedBody: JSON.stringify(bundle),
+      payload: {
+        tone,
+        draftIds: createdDrafts.map((draft) => draft.id),
+      },
+      teachingWeight: 55,
+    });
+
+    return NextResponse.json({
+      bundle,
+      drafts: createdDrafts,
+    });
+  } catch (error) {
+    console.error("[API:ContentGeneration] failure:", error);
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}

--- a/src/app/api/evaluations/route.ts
+++ b/src/app/api/evaluations/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { recordOutcomeEvent } from "@/lib/audit-ledger";
+import {
+  EVALUATION_SUITES,
+  SEEDED_EVALUATION_CASES,
+  compareEvaluationVariants,
+  type EvaluationCaseResult,
+  type EvaluationVariant,
+} from "@/lib/evaluation-bench";
+import { verifyMembership } from "@/lib/permissions";
+
+export const dynamic = "force-dynamic";
+
+function failedCaseSummary(failedCases: EvaluationCaseResult[]) {
+  return failedCases
+    .slice(0, 4)
+    .map((item) => `${item.caseId}: ${Math.round(item.score * 100)}% ${item.gateOutcome}`)
+    .join("; ");
+}
+
+export async function GET(request: NextRequest) {
+  const companyId = request.nextUrl.searchParams.get("companyId");
+  if (!companyId) {
+    return NextResponse.json({ error: "companyId required" }, { status: 400 });
+  }
+
+  const auth = await verifyMembership(request, companyId);
+  if (auth.error) return auth.error;
+
+  const comparison = compareEvaluationVariants();
+  return NextResponse.json({
+    suites: EVALUATION_SUITES,
+    cases: SEEDED_EVALUATION_CASES,
+    comparison,
+  });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const data = await request.json();
+    const companyId = String(data.companyId || "");
+    if (!companyId) {
+      return NextResponse.json({ error: "companyId required" }, { status: 400 });
+    }
+
+    const auth = await verifyMembership(request, companyId);
+    if (auth.error) return auth.error;
+
+    const candidate = (data.candidate || {}) as EvaluationVariant;
+    const persistObservability = Boolean(data.persistObservability);
+    const comparison = compareEvaluationVariants(candidate);
+
+    if (persistObservability && comparison.candidate.failedCases.length > 0) {
+      await recordOutcomeEvent({
+        companyId,
+        actorType: "SYSTEM",
+        entityType: "EVALUATION_SUITE",
+        entityId: comparison.candidate.suiteId,
+        outcomeType: "EVAL_GATE_FAILED",
+        outcomeValue: comparison.promotionGate.status,
+        annotation: failedCaseSummary(comparison.candidate.failedCases),
+        payload: {
+          runId: comparison.candidate.runId,
+          aggregateScore: comparison.candidate.aggregateScore,
+          passRate: comparison.candidate.passRate,
+          failedCases: comparison.candidate.failedCases.map((item) => ({
+            caseId: item.caseId,
+            score: item.score,
+            gateOutcome: item.gateOutcome,
+            reasons: item.reasons,
+          })),
+        },
+        teachingWeight: 90,
+      });
+    }
+
+    return NextResponse.json({
+      comparison,
+      observabilityPublished: persistObservability && comparison.candidate.failedCases.length > 0,
+    });
+  } catch (error) {
+    console.error("[API:Evaluations] failure:", error);
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}

--- a/src/app/api/nba/route.ts
+++ b/src/app/api/nba/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/db";
 import { normalizeSourceHashtags } from "@/lib/hashtags";
 import { verifyMembership } from "@/lib/permissions";
 import { calculateICEScore, normalizeNBAMetrics } from "@/lib/nba-scoring";
+import { computeBlendedPriorityProfile } from "@/lib/scoring-contract";
 import { applyPlanningHitlScoreAdjustment, type NBAKanbanColumn } from "@/lib/planning-hitl";
 import { ensurechecklistPublicIds, nextchecklistPublicId, TRANSACTION_SETTINGS } from "@/lib/source-public-ids";
 import { APP_VERSION, BRAIN_VERSION, NBA_PROMPT_VERSION } from "@/lib/release";
@@ -61,7 +62,30 @@ export async function GET(request: NextRequest) {
             { publicId: "asc" as const },
           ],
     });
-    return NextResponse.json(items);
+    const enriched = items.map((item) => ({
+      ...item,
+      priorityProfile: computeBlendedPriorityProfile(item),
+    }));
+
+    enriched.sort((left, right) => {
+      const leftManual = (left.sortOrder ?? 0) !== 0;
+      const rightManual = (right.sortOrder ?? 0) !== 0;
+      if ((showAll || Boolean(kanbanColumn)) && leftManual !== rightManual) {
+        return leftManual ? -1 : 1;
+      }
+      if ((showAll || Boolean(kanbanColumn)) && leftManual && rightManual && left.sortOrder !== right.sortOrder) {
+        return left.sortOrder - right.sortOrder;
+      }
+      const leftPriority = left.priorityProfile?.score ?? 0;
+      const rightPriority = right.priorityProfile?.score ?? 0;
+      if (leftPriority !== rightPriority) return rightPriority - leftPriority;
+      if ((right.confidenceScore ?? 0) !== (left.confidenceScore ?? 0)) {
+        return (right.confidenceScore ?? 0) - (left.confidenceScore ?? 0);
+      }
+      return (left.publicId ?? Number.MAX_SAFE_INTEGER) - (right.publicId ?? Number.MAX_SAFE_INTEGER);
+    });
+
+    return NextResponse.json(enriched);
   } catch (error) {
     console.error("[API:NBA] Get failure:", error);
     // Iron-Clad: Never return a non-array crash object to the dashboard

--- a/src/app/client-nav.tsx
+++ b/src/app/client-nav.tsx
@@ -19,7 +19,7 @@ import {
   Badge,
   Button
 } from "@mantine/core";
-import { IconChevronRight as ChevronRight, IconSun as Sun, IconMoon as Moon, IconLogout as LogOut, IconUser as UserIcon, IconSettings as SettingsIcon, IconLayoutDashboard as LayoutDashboard, IconDatabase as Database, IconListCheck as ListCheck, IconCircleCheck as CheckCircle2, IconTarget as Target, IconSparkles as Sparkles, IconBolt as Zap, IconChevronDown as ChevronDown, IconHelmet as HardHat, IconLayersIntersect as Layers, IconHistory as History } from "@tabler/icons-react";
+import { IconChevronRight as ChevronRight, IconSun as Sun, IconMoon as Moon, IconLogout as LogOut, IconUser as UserIcon, IconSettings as SettingsIcon, IconLayoutDashboard as LayoutDashboard, IconDatabase as Database, IconListCheck as ListCheck, IconTarget as Target, IconSparkles as Sparkles, IconChevronDown as ChevronDown, IconHelmet as HardHat, IconLayersIntersect as Layers, IconHistory as History, IconFlask as Flask, IconPencil as Pencil } from "@tabler/icons-react";
 import { Logo } from "@/components/ui/logo";
 import { useState, useEffect } from "react";
 import { usePathname, useRouter, useParams } from "next/navigation";
@@ -94,6 +94,22 @@ const pipelineItems = [
     color: "review",
     tone: "review",
   },
+  {
+    key: "evaluations",
+    href: (companyId: string) => `/${companyId}/evaluations`,
+    label: "Evaluations",
+    icon: Flask,
+    color: "strategy",
+    tone: "strategy",
+  },
+  {
+    key: "content-generation",
+    href: (companyId: string) => `/${companyId}/content-generation`,
+    label: "Content",
+    icon: Pencil,
+    color: "knowmore",
+    tone: "knowmore",
+  },
 ];
 
 export function ClientNav() {
@@ -155,6 +171,8 @@ export function ClientNav() {
             tactical: data.counts?.nbaItems || 0,
             review: data.counts?.reviewCount || 0,
             pipeline: data.counts?.pipelineJobs || 0,
+            evaluations: 0,
+            "content-generation": data.counts?.creativeDrafts || 0,
           });
         }
       } catch (err) {

--- a/src/app/client-nav.tsx
+++ b/src/app/client-nav.tsx
@@ -19,7 +19,7 @@ import {
   Badge,
   Button
 } from "@mantine/core";
-import { IconChevronRight as ChevronRight, IconSun as Sun, IconMoon as Moon, IconLogout as LogOut, IconUser as UserIcon, IconSettings as SettingsIcon, IconLayoutDashboard as LayoutDashboard, IconDatabase as Database, IconListCheck as ListCheck, IconTarget as Target, IconSparkles as Sparkles, IconChevronDown as ChevronDown, IconHelmet as HardHat, IconLayersIntersect as Layers, IconHistory as History, IconFlask as Flask, IconPencil as Pencil } from "@tabler/icons-react";
+import { IconChevronRight as ChevronRight, IconSun as Sun, IconMoon as Moon, IconLogout as LogOut, IconUser as UserIcon, IconSettings as SettingsIcon, IconLayoutDashboard as LayoutDashboard, IconDatabase as Database, IconListCheck as ListCheck, IconTarget as Target, IconSparkles as Sparkles, IconChevronDown as ChevronDown, IconHelmet as HardHat, IconLayersIntersect as Layers, IconHistory as History, IconFlask as Flask, IconPencil as Pencil, IconRun as Run } from "@tabler/icons-react";
 import { Logo } from "@/components/ui/logo";
 import { useState, useEffect } from "react";
 import { usePathname, useRouter, useParams } from "next/navigation";
@@ -110,6 +110,14 @@ const pipelineItems = [
     color: "knowmore",
     tone: "knowmore",
   },
+  {
+    key: "athlete",
+    href: (companyId: string) => `/${companyId}/athlete`,
+    label: "Athlete App",
+    icon: Run,
+    color: "checklist",
+    tone: "checklist",
+  },
 ];
 
 export function ClientNav() {
@@ -173,6 +181,7 @@ export function ClientNav() {
             pipeline: data.counts?.pipelineJobs || 0,
             evaluations: 0,
             "content-generation": data.counts?.creativeDrafts || 0,
+            athlete: data.counts?.athleteActivityLogs || 0,
           });
         }
       } catch (err) {

--- a/src/app/client-nav.tsx
+++ b/src/app/client-nav.tsx
@@ -256,7 +256,17 @@ export function ClientNav() {
                   rightSection={
                     <Group gap={4}>
                       {counts[item.key] !== undefined && (
-                        <Badge size="xs" color={item.color} circle>
+                        <Badge
+                          size="xs"
+                          color={item.color}
+                          px={6}
+                          miw={30}
+                          styles={{
+                            label: {
+                              fontVariantNumeric: "tabular-nums",
+                            },
+                          }}
+                        >
                           {counts[item.key]}
                         </Badge>
                       )}

--- a/src/app/client-nav.tsx
+++ b/src/app/client-nav.tsx
@@ -19,7 +19,7 @@ import {
   Badge,
   Button
 } from "@mantine/core";
-import { IconChevronRight as ChevronRight, IconSun as Sun, IconMoon as Moon, IconLogout as LogOut, IconUser as UserIcon, IconSettings as SettingsIcon, IconLayoutDashboard as LayoutDashboard, IconDatabase as Database, IconListCheck as ListCheck, IconTarget as Target, IconSparkles as Sparkles, IconChevronDown as ChevronDown, IconHelmet as HardHat, IconLayersIntersect as Layers, IconHistory as History, IconFlask as Flask, IconPencil as Pencil, IconRun as Run } from "@tabler/icons-react";
+import { IconChevronRight as ChevronRight, IconSun as Sun, IconMoon as Moon, IconLogout as LogOut, IconUser as UserIcon, IconSettings as SettingsIcon, IconLayoutDashboard as LayoutDashboard, IconDatabase as Database, IconListCheck as ListCheck, IconTarget as Target, IconSparkles as Sparkles, IconChevronDown as ChevronDown, IconHelmet as HardHat, IconLayersIntersect as Layers, IconHistory as History, IconFlask as Flask, IconPencil as Pencil, IconRun as Run, IconUsers as Users } from "@tabler/icons-react";
 import { Logo } from "@/components/ui/logo";
 import { useState, useEffect } from "react";
 import { usePathname, useRouter, useParams } from "next/navigation";
@@ -118,6 +118,14 @@ const pipelineItems = [
     color: "checklist",
     tone: "checklist",
   },
+  {
+    key: "athletes",
+    href: (companyId: string) => `/${companyId}/athletes`,
+    label: "Athletes",
+    icon: Users,
+    color: "strategy",
+    tone: "strategy",
+  },
 ];
 
 export function ClientNav() {
@@ -182,6 +190,7 @@ export function ClientNav() {
             evaluations: 0,
             "content-generation": data.counts?.creativeDrafts || 0,
             athlete: data.counts?.athleteActivityLogs || 0,
+            athletes: data.counts?.athleteActivityLogs || 0,
           });
         }
       } catch (err) {
@@ -253,70 +262,75 @@ export function ClientNav() {
                 }}
               />
 
-              {pipelineItems.map((item) => (
-                <NavLink
-                  key={item.key}
-                  label={item.label}
-                  leftSection={
-                    <ThemeIcon color={item.color}>
-                      <item.icon size={14} />
-                    </ThemeIcon>
-                  }
-                  rightSection={
-                    <Group gap={4}>
-                      {counts[item.key] !== undefined && (
-                        <Badge
-                          size="xs"
-                          color={item.color}
-                          px={6}
-                          miw={30}
-                          styles={{
-                            label: {
-                              fontVariantNumeric: "tabular-nums",
-                            },
-                          }}
-                        >
-                          {counts[item.key]}
-                        </Badge>
-                      )}
-                      <ChevronRight size={14} strokeOpacity={0.5} />
-                    </Group>
-                  }
-                  onClick={() => {
-                    const companyId = company?.id || companyIdFromUrl;
-                    if (!companyId) return;
-                    void logClientInteraction({
-                      companyId,
-                      surface: "global-navigation",
-                      interactionType: "PIPELINE_ROUTE_SELECT",
-                      entityType: "ROUTE",
-                      entityId: item.key,
-                      payload: { href: item.href(companyId), label: item.label },
-                      teachingWeight: 30,
-                    });
-                    router.push(item.href(companyId));
-                  }}
-                  active={pathname.includes(item.key)}
-                  variant="subtle"
-                  color={item.color}
-                  styles={{
-                    root: {
-                      backgroundColor: "transparent",
-                      borderLeft: "2px solid transparent",
-                      ...(pathname.includes(item.key) ? getSidebarActiveStyle(item.tone as ModuleTone) : {}),
-                      ...(!pathname.includes(item.key)
-                        ? {
-                            "&:hover": getSidebarHoverStyle(item.tone as ModuleTone),
-                          }
-                        : {}),
-                    },
-                    label: {
-                      color: pathname.includes(item.key) ? "var(--nav-link-active)" : "var(--nav-link-inactive)",
-                      fontWeight: 500,
-                    },
-                  }}
-                />
-              ))}
+              {pipelineItems.map((item) => {
+                const companyId = company?.id || companyIdFromUrl;
+                const itemHref = companyId ? item.href(companyId) : "";
+                const isActive = Boolean(pathname && itemHref && (pathname === itemHref || pathname.startsWith(`${itemHref}/`)));
+
+                return (
+                  <NavLink
+                    key={item.key}
+                    label={item.label}
+                    leftSection={
+                      <ThemeIcon color={item.color}>
+                        <item.icon size={14} />
+                      </ThemeIcon>
+                    }
+                    rightSection={
+                      <Group gap={4}>
+                        {counts[item.key] !== undefined && (
+                          <Badge
+                            size="xs"
+                            color={item.color}
+                            px={6}
+                            miw={30}
+                            styles={{
+                              label: {
+                                fontVariantNumeric: "tabular-nums",
+                              },
+                            }}
+                          >
+                            {counts[item.key]}
+                          </Badge>
+                        )}
+                        <ChevronRight size={14} strokeOpacity={0.5} />
+                      </Group>
+                    }
+                    onClick={() => {
+                      if (!companyId) return;
+                      void logClientInteraction({
+                        companyId,
+                        surface: "global-navigation",
+                        interactionType: "PIPELINE_ROUTE_SELECT",
+                        entityType: "ROUTE",
+                        entityId: item.key,
+                        payload: { href: itemHref, label: item.label },
+                        teachingWeight: 30,
+                      });
+                      router.push(itemHref);
+                    }}
+                    active={isActive}
+                    variant="subtle"
+                    color={item.color}
+                    styles={{
+                      root: {
+                        backgroundColor: "transparent",
+                        borderLeft: "2px solid transparent",
+                        ...(isActive ? getSidebarActiveStyle(item.tone as ModuleTone) : {}),
+                        ...(!isActive
+                          ? {
+                              "&:hover": getSidebarHoverStyle(item.tone as ModuleTone),
+                            }
+                          : {}),
+                      },
+                      label: {
+                        color: isActive ? "var(--nav-link-active)" : "var(--nav-link-inactive)",
+                        fontWeight: 500,
+                      },
+                    }}
+                  />
+                );
+              })}
             </Stack>
           ) : (
             <Box px="md" py="xl">

--- a/src/components/tactical-board.tsx
+++ b/src/components/tactical-board.tsx
@@ -67,6 +67,19 @@ type NBAItem = {
   qualityScore?: number | null;
   urgencyScore?: number | null;
   freshnessScore?: number | null;
+  priorityProfile?: {
+    score: number;
+    manualAnchor: boolean;
+    components: {
+      ice: number;
+      quality: number;
+      urgency: number;
+      freshness: number;
+      human: number;
+      risk: number;
+    };
+    reasons: string[];
+  } | null;
 };
 
 const COLUMNS: {
@@ -76,11 +89,11 @@ const COLUMNS: {
   accent: string;
   tone: "neutral" | "strategy" | "ingress" | "tactical" | "checklist";
 }[] = [
-  { key: "IDEABANK",  label: "Idea Bank", description: "Someday · ICE < 100",  accent: getModuleTheme("neutral").color, tone: "neutral" },
-  { key: "ROADMAP",   label: "Roadmap",   description: "Later · ICE ≥ 100",    accent: getModuleTheme("strategy").color, tone: "strategy" },
-  { key: "BACKLOG",   label: "Backlog",   description: "Sooner · ICE ≥ 250",   accent: getModuleTheme("ingress").color, tone: "ingress" },
-  { key: "TODO",      label: "Next",      description: "Soon · ICE ≥ 500",     accent: getModuleTheme("tactical").color, tone: "tactical" },
-  { key: "CHECKLIST", label: "Now",       description: "Active · ICE ≥ 700",   accent: getModuleTheme("checklist").color, tone: "checklist" },
+  { key: "IDEABANK",  label: "Idea Bank", description: "Someday · priority < 100",  accent: getModuleTheme("neutral").color, tone: "neutral" },
+  { key: "ROADMAP",   label: "Roadmap",   description: "Later · priority ≥ 100",    accent: getModuleTheme("strategy").color, tone: "strategy" },
+  { key: "BACKLOG",   label: "Backlog",   description: "Sooner · priority ≥ 250",   accent: getModuleTheme("ingress").color, tone: "ingress" },
+  { key: "TODO",      label: "Next",      description: "Soon · priority ≥ 500",     accent: getModuleTheme("tactical").color, tone: "tactical" },
+  { key: "CHECKLIST", label: "Now",       description: "Active · priority ≥ 700",   accent: getModuleTheme("checklist").color, tone: "checklist" },
 ];
 
 const COLUMN_OPTIONS = [
@@ -262,31 +275,36 @@ function CardDetailModal({
         </Box>
 
         {/* AI Scores */}
-        {(item.qualityScore != null || item.urgencyScore != null || item.freshnessScore != null) && (
+        {(item.priorityProfile || item.qualityScore != null || item.urgencyScore != null || item.freshnessScore != null) && (
           <Box>
             <Group gap="xs" mb="md">
               <Sparkles size={14} color="var(--mantine-color-ingress-6)" />
-              <Text size="xs" c="dimmed">AI Evaluation Signals</Text>
+              <Text size="xs" c="dimmed">Blended Priority Signals</Text>
             </Group>
             <UnifiedCardSection tone="tactical">
               <SimpleGrid cols={4}>
                 <Stack gap={2}>
-                  <Text size="sm">{fmt(item.qualityScore)}</Text>
-                  <Text size="xs" c="dimmed">Quality</Text>
+                  <Text size="sm">{item.priorityProfile ? Math.round(item.priorityProfile.score) : "—"}</Text>
+                  <Text size="xs" c="dimmed">Priority</Text>
                 </Stack>
                 <Stack gap={2}>
-                  <Text size="sm">{fmt(item.urgencyScore)}</Text>
-                  <Text size="xs" c="dimmed">Urgency</Text>
+                  <Text size="sm">{item.priorityProfile ? fmt(item.priorityProfile.components.human) : "—"}</Text>
+                  <Text size="xs" c="dimmed">Human</Text>
                 </Stack>
                 <Stack gap={2}>
-                  <Text size="sm">{fmt(item.freshnessScore)}</Text>
-                  <Text size="xs" c="dimmed">Freshness</Text>
+                  <Text size="sm">{item.priorityProfile ? fmt(item.priorityProfile.components.risk) : "—"}</Text>
+                  <Text size="xs" c="dimmed">Risk</Text>
                 </Stack>
                 <Stack gap={2}>
                   <Badge color="tactical">{item.candidateState}</Badge>
                   <Text size="xs" c="dimmed">State</Text>
                 </Stack>
               </SimpleGrid>
+              {item.priorityProfile?.reasons?.length ? (
+                <Text size="xs" c="dimmed" mt="sm">
+                  {item.priorityProfile.reasons.slice(0, 4).join(" · ")}
+                </Text>
+              ) : null}
             </UnifiedCardSection>
           </Box>
         )}
@@ -696,9 +714,9 @@ export function TacticalBoard({ companyId }: { companyId: string }) {
                                               {item.candidateState}
                                             </Badge>
                                             <Group gap={4}>
-                                              <MetaText>ICE</MetaText>
+                                              <MetaText>{item.priorityProfile ? "PRIORITY" : "ICE"}</MetaText>
                                               <Text size="xs" style={{ color: col.accent, fontVariantNumeric: "tabular-nums" }}>
-                                                {Math.round(item.iceScore)}
+                                                {Math.round(item.priorityProfile?.score ?? item.iceScore)}
                                               </Text>
                                             </Group>
                                           </Group>

--- a/src/lib/athlete-activity.ts
+++ b/src/lib/athlete-activity.ts
@@ -9,6 +9,17 @@ export const ATHLETE_ACTIVITY_TYPES: Array<{ value: AthleteActivityType; label: 
   { value: "NOTE", label: "Note" },
 ];
 
+export type AthleteMetrics = {
+  sleepHours?: number;
+  soreness?: number;
+  stress?: number;
+  mood?: number;
+  hydration?: number;
+  bodyWeight?: number;
+  painArea?: string;
+  nutritionNote?: string;
+};
+
 export function normalizeActivityType(value: unknown): AthleteActivityType {
   const candidate = String(value || "").toUpperCase();
   return ATHLETE_ACTIVITY_TYPES.some((item) => item.value === candidate)
@@ -28,6 +39,45 @@ export function normalizeDurationMinutes(value: unknown) {
   return Math.max(1, Math.min(24 * 60, Math.round(numeric)));
 }
 
+function optionalBoundedNumber(value: unknown, min: number, max: number, decimals = 0) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return undefined;
+  const bounded = Math.max(min, Math.min(max, numeric));
+  const factor = 10 ** decimals;
+  return Math.round(bounded * factor) / factor;
+}
+
+function optionalShortText(value: unknown, maxLength = 140) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, maxLength) : undefined;
+}
+
+export function normalizeAthleteMetrics(value: unknown): AthleteMetrics {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const source = value as Record<string, unknown>;
+  const metrics: AthleteMetrics = {};
+  const sleepHours = optionalBoundedNumber(source.sleepHours, 0, 24, 1);
+  const soreness = optionalBoundedNumber(source.soreness, 1, 10);
+  const stress = optionalBoundedNumber(source.stress, 1, 10);
+  const mood = optionalBoundedNumber(source.mood, 1, 10);
+  const hydration = optionalBoundedNumber(source.hydration, 1, 10);
+  const bodyWeight = optionalBoundedNumber(source.bodyWeight, 20, 400, 1);
+  const painArea = optionalShortText(source.painArea);
+  const nutritionNote = optionalShortText(source.nutritionNote, 220);
+
+  if (sleepHours !== undefined) metrics.sleepHours = sleepHours;
+  if (soreness !== undefined) metrics.soreness = soreness;
+  if (stress !== undefined) metrics.stress = stress;
+  if (mood !== undefined) metrics.mood = mood;
+  if (hydration !== undefined) metrics.hydration = hydration;
+  if (bodyWeight !== undefined) metrics.bodyWeight = bodyWeight;
+  if (painArea) metrics.painArea = painArea;
+  if (nutritionNote) metrics.nutritionNote = nutritionNote;
+
+  return metrics;
+}
+
 export function dayBounds(dateInput?: string | null) {
   const safeDate = typeof dateInput === "string" && /^\d{4}-\d{2}-\d{2}$/.test(dateInput)
     ? dateInput
@@ -37,12 +87,45 @@ export function dayBounds(dateInput?: string | null) {
   return { safeDate, start, end };
 }
 
-export function summarizeAthleteDay(logs: Array<{ durationMinutes: number | null; readiness: number | null; intensity: number | null; completionState: string }>) {
+type AthleteSummaryLog = {
+  athleteEmail?: string | null;
+  athleteName?: string | null;
+  durationMinutes: number | null;
+  readiness: number | null;
+  intensity: number | null;
+  completionState: string;
+  metrics?: unknown;
+};
+
+function metricValue(log: AthleteSummaryLog, key: keyof AthleteMetrics) {
+  if (!log.metrics || typeof log.metrics !== "object" || Array.isArray(log.metrics)) return undefined;
+  const value = (log.metrics as AthleteMetrics)[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+function average(values: number[]) {
+  return values.length ? Math.round(values.reduce((sum, value) => sum + value, 0) / values.length) : null;
+}
+
+function averageDecimal(values: number[], decimals = 1) {
+  if (!values.length) return null;
+  const factor = 10 ** decimals;
+  return Math.round((values.reduce((sum, value) => sum + value, 0) / values.length) * factor) / factor;
+}
+
+export function summarizeAthleteDay(logs: AthleteSummaryLog[]) {
   const completed = logs.filter((log) => log.completionState === "COMPLETED").length;
   const totalMinutes = logs.reduce((sum, log) => sum + (log.durationMinutes ?? 0), 0);
   const readinessValues = logs.map((log) => log.readiness).filter((value): value is number => typeof value === "number");
   const intensityValues = logs.map((log) => log.intensity).filter((value): value is number => typeof value === "number");
-  const average = (values: number[]) => values.length ? Math.round(values.reduce((sum, value) => sum + value, 0) / values.length) : null;
+  const sleepValues = logs.map((log) => metricValue(log, "sleepHours")).filter((value): value is number => typeof value === "number");
+  const sorenessValues = logs.map((log) => metricValue(log, "soreness")).filter((value): value is number => typeof value === "number");
+  const stressValues = logs.map((log) => metricValue(log, "stress")).filter((value): value is number => typeof value === "number");
+  const hydrationValues = logs.map((log) => metricValue(log, "hydration")).filter((value): value is number => typeof value === "number");
+  const painReports = logs.filter((log) => {
+    if (!log.metrics || typeof log.metrics !== "object" || Array.isArray(log.metrics)) return false;
+    return Boolean((log.metrics as AthleteMetrics).painArea);
+  }).length;
 
   return {
     totalLogs: logs.length,
@@ -50,5 +133,40 @@ export function summarizeAthleteDay(logs: Array<{ durationMinutes: number | null
     totalMinutes,
     averageReadiness: average(readinessValues),
     averageIntensity: average(intensityValues),
+    averageSleepHours: averageDecimal(sleepValues),
+    averageSoreness: average(sorenessValues),
+    averageStress: average(stressValues),
+    averageHydration: average(hydrationValues),
+    painReports,
   };
+}
+
+export function summarizeAthleteTeam(logs: AthleteSummaryLog[]) {
+  const athleteMap = new Map<string, {
+    athleteEmail: string;
+    athleteName: string | null;
+    logs: AthleteSummaryLog[];
+  }>();
+
+  for (const log of logs) {
+    const email = (log.athleteEmail || "unknown").trim().toLowerCase();
+    const existing = athleteMap.get(email);
+    if (existing) {
+      existing.logs.push(log);
+    } else {
+      athleteMap.set(email, {
+        athleteEmail: email,
+        athleteName: log.athleteName || null,
+        logs: [log],
+      });
+    }
+  }
+
+  return Array.from(athleteMap.values())
+    .map((athlete) => ({
+      athleteEmail: athlete.athleteEmail,
+      athleteName: athlete.athleteName,
+      ...summarizeAthleteDay(athlete.logs),
+    }))
+    .sort((a, b) => b.totalLogs - a.totalLogs || a.athleteEmail.localeCompare(b.athleteEmail));
 }

--- a/src/lib/athlete-activity.ts
+++ b/src/lib/athlete-activity.ts
@@ -1,0 +1,54 @@
+export type AthleteActivityType = "TRAINING" | "RECOVERY" | "NUTRITION" | "WELLNESS" | "MATCH" | "NOTE";
+
+export const ATHLETE_ACTIVITY_TYPES: Array<{ value: AthleteActivityType; label: string }> = [
+  { value: "TRAINING", label: "Training" },
+  { value: "RECOVERY", label: "Recovery" },
+  { value: "NUTRITION", label: "Nutrition" },
+  { value: "WELLNESS", label: "Wellness" },
+  { value: "MATCH", label: "Match" },
+  { value: "NOTE", label: "Note" },
+];
+
+export function normalizeActivityType(value: unknown): AthleteActivityType {
+  const candidate = String(value || "").toUpperCase();
+  return ATHLETE_ACTIVITY_TYPES.some((item) => item.value === candidate)
+    ? candidate as AthleteActivityType
+    : "TRAINING";
+}
+
+export function clampAthleteScore(value: unknown) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return undefined;
+  return Math.max(1, Math.min(10, Math.round(numeric)));
+}
+
+export function normalizeDurationMinutes(value: unknown) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) return undefined;
+  return Math.max(1, Math.min(24 * 60, Math.round(numeric)));
+}
+
+export function dayBounds(dateInput?: string | null) {
+  const safeDate = typeof dateInput === "string" && /^\d{4}-\d{2}-\d{2}$/.test(dateInput)
+    ? dateInput
+    : new Date().toISOString().slice(0, 10);
+  const start = new Date(`${safeDate}T00:00:00.000Z`);
+  const end = new Date(`${safeDate}T23:59:59.999Z`);
+  return { safeDate, start, end };
+}
+
+export function summarizeAthleteDay(logs: Array<{ durationMinutes: number | null; readiness: number | null; intensity: number | null; completionState: string }>) {
+  const completed = logs.filter((log) => log.completionState === "COMPLETED").length;
+  const totalMinutes = logs.reduce((sum, log) => sum + (log.durationMinutes ?? 0), 0);
+  const readinessValues = logs.map((log) => log.readiness).filter((value): value is number => typeof value === "number");
+  const intensityValues = logs.map((log) => log.intensity).filter((value): value is number => typeof value === "number");
+  const average = (values: number[]) => values.length ? Math.round(values.reduce((sum, value) => sum + value, 0) / values.length) : null;
+
+  return {
+    totalLogs: logs.length,
+    completed,
+    totalMinutes,
+    averageReadiness: average(readinessValues),
+    averageIntensity: average(intensityValues),
+  };
+}

--- a/src/lib/content-generation.ts
+++ b/src/lib/content-generation.ts
@@ -1,0 +1,209 @@
+export type ContentTone = "clear" | "bold" | "executive" | "friendly" | "technical";
+
+export type ContentGenerationInput = {
+  companyName: string;
+  industry?: string | null;
+  description?: string | null;
+  targetMarket?: string | null;
+  productContext: string[];
+  competitorContext: string[];
+  goalContext: string[];
+  tone: ContentTone;
+  campaignBrief?: string | null;
+};
+
+export type GeneratedContentBundle = {
+  tone: ContentTone;
+  positioning: {
+    audience: string;
+    promise: string;
+    proof: string;
+    competitorAngle: string;
+  };
+  emailSubjectLines: string[];
+  adCopy: Array<{
+    platform: "Facebook" | "Google" | "LinkedIn";
+    headline: string;
+    primaryText: string;
+    cta: string;
+    characterLimit: string;
+  }>;
+  socialPosts: Array<{
+    platform: "Twitter" | "LinkedIn" | "Facebook";
+    post: string;
+    characterLimit: string;
+  }>;
+  landingPage: {
+    heroHeadline: string;
+    heroSubheadline: string;
+    benefits: string[];
+    cta: string;
+  };
+};
+
+const TONE_PROFILES: Record<ContentTone, { verb: string; adjective: string; cta: string }> = {
+  clear: { verb: "turn", adjective: "clear", cta: "See the next best action" },
+  bold: { verb: "accelerate", adjective: "decisive", cta: "Lead the market" },
+  executive: { verb: "align", adjective: "board-ready", cta: "Review the plan" },
+  friendly: { verb: "make", adjective: "practical", cta: "Start improving today" },
+  technical: { verb: "operationalize", adjective: "evidence-backed", cta: "Inspect the workflow" },
+};
+
+const PLATFORM_LIMITS = {
+  emailSubject: 72,
+  facebookAd: 125,
+  googleHeadline: 30,
+  googleDescription: 90,
+  linkedinAd: 150,
+  twitterPost: 280,
+  linkedinPost: 600,
+  facebookPost: 500,
+};
+
+function compact(value: string, maxLength: number) {
+  const normalized = String(value || "").replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) return normalized;
+  return normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd();
+}
+
+function firstMeaningful(values: Array<string | null | undefined>, fallback: string) {
+  const found = values.find((value) => typeof value === "string" && value.trim().length > 0);
+  return found?.trim() || fallback;
+}
+
+function phraseFromContext(values: string[], fallback: string) {
+  const source = firstMeaningful(values, fallback);
+  return compact(source.replace(/[#*_`]/g, ""), 110);
+}
+
+function inferAudience(input: ContentGenerationInput) {
+  return compact(
+    firstMeaningful(
+      [input.targetMarket, input.industry ? `${input.industry} teams` : null, input.description],
+      "growth teams",
+    ),
+    80,
+  );
+}
+
+function inferPromise(input: ContentGenerationInput) {
+  const profile = TONE_PROFILES[input.tone] ?? TONE_PROFILES.clear;
+  const productSignal = phraseFromContext(input.productContext, input.description || "market and product context");
+  const brief = input.campaignBrief ? ` for ${input.campaignBrief}` : "";
+  return compact(`${profile.verb} ${productSignal}${brief} into ${profile.adjective} marketing action`, 140);
+}
+
+function inferProof(input: ContentGenerationInput) {
+  return phraseFromContext(
+    [...input.goalContext, ...input.productContext],
+    "built from product, customer, and market evidence already in CHECKLIST",
+  );
+}
+
+function inferCompetitorAngle(input: ContentGenerationInput) {
+  return phraseFromContext(
+    input.competitorContext,
+    "differentiate against slower, less evidence-backed alternatives",
+  );
+}
+
+function titleCase(value: string) {
+  return value
+    .split(/\s+/)
+    .map((word) => word ? `${word[0].toUpperCase()}${word.slice(1).toLowerCase()}` : word)
+    .join(" ");
+}
+
+export function generateContentBundle(input: ContentGenerationInput): GeneratedContentBundle {
+  const profile = TONE_PROFILES[input.tone] ?? TONE_PROFILES.clear;
+  const audience = inferAudience(input);
+  const promise = inferPromise(input);
+  const proof = inferProof(input);
+  const competitorAngle = inferCompetitorAngle(input);
+  const companyName = compact(input.companyName || "Your company", 48);
+
+  const subjectSeeds = [
+    `${companyName}: ${titleCase(profile.adjective)} Growth Starts Here`,
+    `A better way to ${profile.verb} ${audience}`,
+    `Turn market context into action this week`,
+    `${titleCase(audience)} deserve sharper recommendations`,
+    `What to do next, backed by your evidence`,
+  ];
+
+  const emailSubjectLines = subjectSeeds.map((subject) => compact(subject, PLATFORM_LIMITS.emailSubject));
+
+  const adCopy = [
+    {
+      platform: "Facebook" as const,
+      headline: compact(`${companyName} for ${audience}`, 40),
+      primaryText: compact(`${promise}. Use your product and competitor evidence to decide what to say next.`, PLATFORM_LIMITS.facebookAd),
+      cta: profile.cta,
+      characterLimit: `${PLATFORM_LIMITS.facebookAd} primary-text chars`,
+    },
+    {
+      platform: "Google" as const,
+      headline: compact(`${profile.adjective} marketing`, PLATFORM_LIMITS.googleHeadline),
+      primaryText: compact(`${promise}. ${profile.cta}.`, PLATFORM_LIMITS.googleDescription),
+      cta: "Learn more",
+      characterLimit: `${PLATFORM_LIMITS.googleHeadline} headline / ${PLATFORM_LIMITS.googleDescription} description chars`,
+    },
+    {
+      platform: "LinkedIn" as const,
+      headline: compact(`${companyName} helps ${audience}`, 70),
+      primaryText: compact(`${proof}. ${competitorAngle}. ${profile.cta}.`, PLATFORM_LIMITS.linkedinAd),
+      cta: "Request a review",
+      characterLimit: `${PLATFORM_LIMITS.linkedinAd} intro chars`,
+    },
+  ];
+
+  const socialPosts = [
+    {
+      platform: "Twitter" as const,
+      post: compact(`${companyName} helps ${audience} ${promise}. The edge: ${competitorAngle}.`, PLATFORM_LIMITS.twitterPost),
+      characterLimit: `${PLATFORM_LIMITS.twitterPost} chars`,
+    },
+    {
+      platform: "LinkedIn" as const,
+      post: compact(`${audience} do not need more generic marketing ideas. They need ${profile.adjective} actions grounded in product, customer, and competitor evidence. ${companyName} helps teams ${promise}.`, PLATFORM_LIMITS.linkedinPost),
+      characterLimit: `${PLATFORM_LIMITS.linkedinPost} chars`,
+    },
+    {
+      platform: "Facebook" as const,
+      post: compact(`Marketing works better when every message has evidence behind it. ${companyName} helps ${audience} ${promise}.`, PLATFORM_LIMITS.facebookPost),
+      characterLimit: `${PLATFORM_LIMITS.facebookPost} chars`,
+    },
+  ];
+
+  return {
+    tone: input.tone,
+    positioning: {
+      audience,
+      promise,
+      proof,
+      competitorAngle,
+    },
+    emailSubjectLines,
+    adCopy,
+    socialPosts,
+    landingPage: {
+      heroHeadline: compact(`${titleCase(profile.adjective)} marketing decisions for ${audience}`, 86),
+      heroSubheadline: compact(`${companyName} helps you ${promise}, using the product and competitor context your team already trusts.`, 180),
+      benefits: [
+        compact(`Ground every campaign in live product and market evidence: ${proof}.`, 120),
+        compact(`Sharpen differentiation with competitor context: ${competitorAngle}.`, 120),
+        compact(`Move from content ideas to ${profile.adjective} next actions without manual blank-page work.`, 120),
+      ],
+      cta: profile.cta,
+    },
+  };
+}
+
+export function serializeContentSection(title: string, value: unknown) {
+  if (Array.isArray(value)) {
+    return [`# ${title}`, "", ...value.map((item) => `- ${String(item)}`)].join("\n");
+  }
+  if (typeof value === "object" && value !== null) {
+    return [`# ${title}`, "", JSON.stringify(value, null, 2)].join("\n");
+  }
+  return [`# ${title}`, "", String(value ?? "")].join("\n");
+}

--- a/src/lib/evaluation-bench.ts
+++ b/src/lib/evaluation-bench.ts
@@ -1,0 +1,509 @@
+export type EvaluationCaseKind =
+  | "GROUNDED_ANSWER"
+  | "SEARCH_RANKING"
+  | "KPI_PULSE"
+  | "WORKFLOW_BLUEPRINT"
+  | "COMPETITIVE_BRIEF"
+  | "DATA_READINESS"
+  | "RECOMMENDATION";
+
+export type EvaluationRubricKey =
+  | "evidenceUse"
+  | "citationCorrectness"
+  | "actionability"
+  | "duplication"
+  | "unsafeConfidence"
+  | "tenantIsolation"
+  | "downstreamQuality";
+
+export type EvaluationCase = {
+  id: string;
+  suiteId: string;
+  title: string;
+  kind: EvaluationCaseKind;
+  input: {
+    query: string;
+    intent: "execution" | "strategy" | "evidence" | "knowledge";
+  };
+  expectedEvidenceTerms: string[];
+  expectedBehaviors: string[];
+  forbiddenBehaviors: string[];
+  rubricWeights: Partial<Record<EvaluationRubricKey, number>>;
+  gate: {
+    minimumScore: number;
+    highRisk: boolean;
+    onFail: "ADVISORY" | "REVIEW_REQUIRED" | "BLOCK";
+  };
+};
+
+type FixtureRecord = {
+  id: string;
+  entityType: "SOURCE" | "TOPIC" | "FLASHCARD" | "GOALCARD" | "TASK" | "PIPELINE_JOB" | "WORKFLOW_BLUEPRINT";
+  title: string;
+  body: string;
+  href: string;
+  score: number;
+  tenantMarker: "synthetic";
+};
+
+export type EvaluationVariant = {
+  label?: string;
+  evidenceStrictness?: "baseline" | "strict";
+  confidencePolicy?: "baseline" | "risk_averse";
+  actionabilityBoost?: number;
+};
+
+export type EvaluationCaseResult = {
+  caseId: string;
+  title: string;
+  kind: EvaluationCaseKind;
+  score: number;
+  passed: boolean;
+  gateOutcome: "PASS" | "ADVISORY" | "REVIEW_REQUIRED" | "BLOCK";
+  reasons: string[];
+  rubricScores: Record<EvaluationRubricKey, number>;
+  output: {
+    confidence: "LOW" | "MEDIUM" | "HIGH";
+    summary: string;
+    evidenceIds: string[];
+    nextActions: string[];
+  };
+};
+
+export type EvaluationRun = {
+  runId: string;
+  suiteId: string;
+  label: string;
+  generatedAt: string;
+  aggregateScore: number;
+  passRate: number;
+  passed: boolean;
+  gateOutcome: "PASS" | "ADVISORY" | "REVIEW_REQUIRED" | "BLOCK";
+  cases: EvaluationCaseResult[];
+  failedCases: EvaluationCaseResult[];
+  trends: {
+    totalCases: number;
+    passedCases: number;
+    highRiskFailures: number;
+    advisoryFailures: number;
+  };
+};
+
+export type EvaluationComparison = {
+  baseline: EvaluationRun;
+  candidate: EvaluationRun;
+  delta: number;
+  regressedCases: Array<{
+    caseId: string;
+    title: string;
+    baselineScore: number;
+    candidateScore: number;
+  }>;
+  improvedCases: Array<{
+    caseId: string;
+    title: string;
+    baselineScore: number;
+    candidateScore: number;
+  }>;
+  promotionGate: {
+    status: "PASS" | "ADVISORY" | "REVIEW_REQUIRED" | "BLOCK";
+    reason: string;
+  };
+};
+
+const DEFAULT_RUBRIC_WEIGHTS: Record<EvaluationRubricKey, number> = {
+  evidenceUse: 0.22,
+  citationCorrectness: 0.18,
+  actionability: 0.18,
+  duplication: 0.08,
+  unsafeConfidence: 0.14,
+  tenantIsolation: 0.1,
+  downstreamQuality: 0.1,
+};
+
+export const EVALUATION_SUITES = [
+  {
+    id: "intelligence-quality-v1",
+    name: "Intelligence Quality Gate v1",
+    description: "Synthetic fixture replay for grounded answers, recommendation quality, search, KPI, workflow, competitor, and data-readiness behavior.",
+    advisoryThreshold: 0.78,
+    enforceableThreshold: 0.86,
+  },
+];
+
+const FIXTURE_RECORDS: FixtureRecord[] = [
+  {
+    id: "src-retention-drop",
+    entityType: "SOURCE",
+    title: "Synthetic Q2 retention source",
+    body: "Synthetic evidence says enterprise retention fell after onboarding delays and missing implementation checklists.",
+    href: "/fixture/data",
+    score: 30,
+    tenantMarker: "synthetic",
+  },
+  {
+    id: "topic-onboarding",
+    entityType: "TOPIC",
+    title: "Onboarding reliability",
+    body: "The company tracks onboarding speed, checklist completion, and support handoffs as key retention drivers.",
+    href: "/fixture/topics",
+    score: 25,
+    tenantMarker: "synthetic",
+  },
+  {
+    id: "task-onboarding-playbook",
+    entityType: "TASK",
+    title: "Repair onboarding checklist",
+    body: "Create a checklist that assigns owner, deadline, and evidence review for every enterprise onboarding blocker.",
+    href: "/fixture/tactical",
+    score: 28,
+    tenantMarker: "synthetic",
+  },
+  {
+    id: "workflow-research-knowledge",
+    entityType: "WORKFLOW_BLUEPRINT",
+    title: "Research To Knowmore",
+    body: "Ingest evidence, search related context, generate grounded knowledge, and route conflicts to review.",
+    href: "/fixture/workflows",
+    score: 22,
+    tenantMarker: "synthetic",
+  },
+  {
+    id: "source-competitor-price",
+    entityType: "SOURCE",
+    title: "Synthetic competitor pricing change",
+    body: "A competitor launched annual onboarding bundles and mentions faster enterprise activation on its pricing page.",
+    href: "/fixture/data",
+    score: 27,
+    tenantMarker: "synthetic",
+  },
+  {
+    id: "source-data-warning",
+    entityType: "SOURCE",
+    title: "Synthetic stale CRM export",
+    body: "The latest CRM export is 46 days old and lacks lifecycle-stage fields needed for reliable pipeline recommendations.",
+    href: "/fixture/data",
+    score: 26,
+    tenantMarker: "synthetic",
+  },
+  {
+    id: "goal-expansion",
+    entityType: "GOALCARD",
+    title: "Increase enterprise expansion",
+    body: "Expansion depends on stronger onboarding evidence, customer-health signals, and clear action ownership.",
+    href: "/fixture/goals",
+    score: 24,
+    tenantMarker: "synthetic",
+  },
+];
+
+export const SEEDED_EVALUATION_CASES: EvaluationCase[] = [
+  {
+    id: "ga-retention-evidence",
+    suiteId: "intelligence-quality-v1",
+    title: "Grounded answer cites retention evidence",
+    kind: "GROUNDED_ANSWER",
+    input: { query: "Why did enterprise retention fall and what should we do?", intent: "evidence" },
+    expectedEvidenceTerms: ["retention", "onboarding", "implementation checklists"],
+    expectedBehaviors: ["cite evidence", "name a next action", "avoid unsupported certainty"],
+    forbiddenBehaviors: ["guarantee", "other tenant", "legal certification"],
+    rubricWeights: { evidenceUse: 0.28, citationCorrectness: 0.22, actionability: 0.2, unsafeConfidence: 0.18, tenantIsolation: 0.12 },
+    gate: { minimumScore: 0.84, highRisk: true, onFail: "REVIEW_REQUIRED" },
+  },
+  {
+    id: "search-ranks-actionable-task",
+    suiteId: "intelligence-quality-v1",
+    title: "Search ranks actionable onboarding work",
+    kind: "SEARCH_RANKING",
+    input: { query: "onboarding checklist blocker", intent: "execution" },
+    expectedEvidenceTerms: ["Repair onboarding checklist", "owner", "deadline"],
+    expectedBehaviors: ["rank task evidence", "preserve source trace"],
+    forbiddenBehaviors: ["duplicate recommendation", "unrelated campaign"],
+    rubricWeights: { evidenceUse: 0.24, citationCorrectness: 0.18, actionability: 0.22, duplication: 0.16, downstreamQuality: 0.2 },
+    gate: { minimumScore: 0.8, highRisk: false, onFail: "ADVISORY" },
+  },
+  {
+    id: "kpi-pulse-explains-driver",
+    suiteId: "intelligence-quality-v1",
+    title: "KPI pulse explains the driver before prescribing",
+    kind: "KPI_PULSE",
+    input: { query: "retention KPI pulse onboarding driver", intent: "strategy" },
+    expectedEvidenceTerms: ["retention", "onboarding", "drivers"],
+    expectedBehaviors: ["explain driver", "separate signal from action"],
+    forbiddenBehaviors: ["metric changed because AI says so"],
+    rubricWeights: { evidenceUse: 0.2, actionability: 0.18, unsafeConfidence: 0.22, downstreamQuality: 0.22, citationCorrectness: 0.18 },
+    gate: { minimumScore: 0.78, highRisk: false, onFail: "ADVISORY" },
+  },
+  {
+    id: "workflow-blueprint-safe-replay",
+    suiteId: "intelligence-quality-v1",
+    title: "Workflow replay stays bounded and reviewable",
+    kind: "WORKFLOW_BLUEPRINT",
+    input: { query: "research to knowledge workflow conflict review", intent: "execution" },
+    expectedEvidenceTerms: ["Research To Knowmore", "conflicts", "review"],
+    expectedBehaviors: ["describe steps", "no production mutation", "route conflicts"],
+    forbiddenBehaviors: ["execute live write", "skip review"],
+    rubricWeights: { downstreamQuality: 0.26, actionability: 0.2, evidenceUse: 0.2, unsafeConfidence: 0.18, tenantIsolation: 0.16 },
+    gate: { minimumScore: 0.86, highRisk: true, onFail: "BLOCK" },
+  },
+  {
+    id: "competitive-change-brief",
+    suiteId: "intelligence-quality-v1",
+    title: "Competitive change brief links change to response",
+    kind: "COMPETITIVE_BRIEF",
+    input: { query: "competitor pricing onboarding bundle response", intent: "strategy" },
+    expectedEvidenceTerms: ["competitor", "pricing", "onboarding bundles"],
+    expectedBehaviors: ["explain what changed", "recommend response", "cite source"],
+    forbiddenBehaviors: ["copy competitor", "unsupported market claim"],
+    rubricWeights: { evidenceUse: 0.24, citationCorrectness: 0.18, actionability: 0.24, unsafeConfidence: 0.16, downstreamQuality: 0.18 },
+    gate: { minimumScore: 0.8, highRisk: false, onFail: "ADVISORY" },
+  },
+  {
+    id: "data-readiness-warning",
+    suiteId: "intelligence-quality-v1",
+    title: "Data readiness warns before recommending",
+    kind: "DATA_READINESS",
+    input: { query: "CRM export stale lifecycle stage warning", intent: "evidence" },
+    expectedEvidenceTerms: ["CRM export", "46 days old", "lifecycle-stage"],
+    expectedBehaviors: ["lower confidence", "request fresh source", "mark data readiness"],
+    forbiddenBehaviors: ["high confidence", "ignore stale"],
+    rubricWeights: { evidenceUse: 0.22, unsafeConfidence: 0.26, citationCorrectness: 0.16, actionability: 0.18, downstreamQuality: 0.18 },
+    gate: { minimumScore: 0.86, highRisk: true, onFail: "REVIEW_REQUIRED" },
+  },
+  {
+    id: "recommendation-owned-action",
+    suiteId: "intelligence-quality-v1",
+    title: "Recommendation has evidence, owner, and next step",
+    kind: "RECOMMENDATION",
+    input: { query: "recommend next enterprise expansion action", intent: "strategy" },
+    expectedEvidenceTerms: ["enterprise expansion", "onboarding evidence", "action ownership"],
+    expectedBehaviors: ["recommend one action", "explain evidence", "include owner"],
+    forbiddenBehaviors: ["many vague actions", "guarantee outcome"],
+    rubricWeights: { evidenceUse: 0.22, actionability: 0.26, duplication: 0.12, unsafeConfidence: 0.14, downstreamQuality: 0.26 },
+    gate: { minimumScore: 0.82, highRisk: true, onFail: "REVIEW_REQUIRED" },
+  },
+];
+
+function tokenize(value: string) {
+  return String(value || "")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/g)
+    .filter((token) => token.length >= 2);
+}
+
+function clampUnit(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function scoreTextCoverage(text: string, terms: string[]) {
+  if (terms.length === 0) return 1;
+  const normalized = text.toLowerCase();
+  const hits = terms.filter((term) => normalized.includes(term.toLowerCase())).length;
+  return hits / terms.length;
+}
+
+function searchFixtureRecords(query: string, intent: EvaluationCase["input"]["intent"]) {
+  const queryTokens = tokenize(query);
+  const intentBoost = (record: FixtureRecord) => {
+    if (intent === "execution" && ["TASK", "PIPELINE_JOB", "WORKFLOW_BLUEPRINT"].includes(record.entityType)) return 8;
+    if (intent === "strategy" && ["GOALCARD", "TOPIC", "TASK"].includes(record.entityType)) return 7;
+    if (intent === "evidence" && ["SOURCE", "FLASHCARD", "TOPIC"].includes(record.entityType)) return 7;
+    return 0;
+  };
+
+  return FIXTURE_RECORDS.map((record) => {
+    const haystack = tokenize(`${record.title} ${record.body}`);
+    const overlap = queryTokens.reduce((sum, token) => sum + (haystack.includes(token) ? 4 : 0), 0);
+    return { ...record, replayScore: record.score + overlap + intentBoost(record) };
+  })
+    .filter((record) => record.replayScore > 0)
+    .sort((left, right) => right.replayScore - left.replayScore)
+    .slice(0, 5);
+}
+
+function replayCase(testCase: EvaluationCase, variant: EvaluationVariant) {
+  const records = searchFixtureRecords(testCase.input.query, testCase.input.intent);
+  const evidence = variant.evidenceStrictness === "strict"
+    ? records.filter((record) => scoreTextCoverage(`${record.title} ${record.body}`, testCase.expectedEvidenceTerms) > 0)
+    : records;
+  const selectedEvidence = (evidence.length > 0 ? evidence : records).slice(0, 4);
+  const summary = selectedEvidence
+    .slice(0, 3)
+    .map((record) => `${record.title}: ${record.body}`)
+    .join(" ");
+  const nextActions = [
+    testCase.kind === "WORKFLOW_BLUEPRINT"
+      ? "Replay the workflow against synthetic fixture data before activating the live blueprint."
+      : "Review the cited synthetic evidence before promoting the recommendation.",
+    testCase.gate.highRisk
+      ? "Require human review if the case misses its gate threshold."
+      : "Treat failures as advisory until the rubric stabilizes.",
+  ];
+  const evidenceCoverage = scoreTextCoverage(summary, testCase.expectedEvidenceTerms);
+  const behaviorCoverage = scoreTextCoverage(`${summary} ${nextActions.join(" ")}`, testCase.expectedBehaviors);
+  const forbiddenHits = testCase.forbiddenBehaviors.filter((term) => scoreTextCoverage(summary, [term]) > 0).length;
+  const unsafeConfidencePenalty =
+    variant.confidencePolicy === "risk_averse" && testCase.forbiddenBehaviors.includes("high confidence")
+      ? 0
+      : evidenceCoverage < 0.5
+        ? 0.35
+        : 0;
+
+  const confidence: EvaluationCaseResult["output"]["confidence"] = evidenceCoverage >= 0.78 && unsafeConfidencePenalty === 0
+    ? "HIGH"
+    : evidenceCoverage >= 0.45
+      ? "MEDIUM"
+      : "LOW";
+
+  return {
+    summary,
+    selectedEvidence,
+    nextActions,
+    coverage: {
+      evidenceCoverage,
+      behaviorCoverage,
+      forbiddenPenalty: forbiddenHits > 0 ? 0.35 : 0,
+      unsafeConfidencePenalty,
+    },
+    confidence,
+  };
+}
+
+function normalizedWeights(testCase: EvaluationCase) {
+  const weights = { ...DEFAULT_RUBRIC_WEIGHTS, ...testCase.rubricWeights };
+  const total = Object.values(weights).reduce((sum, value) => sum + value, 0) || 1;
+  return Object.fromEntries(
+    Object.entries(weights).map(([key, value]) => [key, value / total]),
+  ) as Record<EvaluationRubricKey, number>;
+}
+
+function evaluateCase(testCase: EvaluationCase, variant: EvaluationVariant): EvaluationCaseResult {
+  const replay = replayCase(testCase, variant);
+  const weights = normalizedWeights(testCase);
+  const actionabilityBoost = clampUnit(Number(variant.actionabilityBoost ?? 0) / 100);
+  const rubricScores: Record<EvaluationRubricKey, number> = {
+    evidenceUse: clampUnit(replay.coverage.evidenceCoverage),
+    citationCorrectness: clampUnit(replay.selectedEvidence.length / Math.min(3, testCase.expectedEvidenceTerms.length || 3)),
+    actionability: clampUnit(0.55 + replay.coverage.behaviorCoverage * 0.35 + actionabilityBoost),
+    duplication: 0.9,
+    unsafeConfidence: clampUnit(1 - replay.coverage.unsafeConfidencePenalty),
+    tenantIsolation: replay.selectedEvidence.every((record) => record.tenantMarker === "synthetic") ? 1 : 0,
+    downstreamQuality: clampUnit(0.5 + replay.coverage.behaviorCoverage * 0.35 + replay.coverage.evidenceCoverage * 0.15),
+  };
+  const weightedScore = Object.entries(rubricScores).reduce(
+    (sum, [key, value]) => sum + value * weights[key as EvaluationRubricKey],
+    0,
+  );
+  const score = clampUnit(weightedScore - replay.coverage.forbiddenPenalty);
+  const passed = score >= testCase.gate.minimumScore;
+  const gateOutcome = passed ? "PASS" : testCase.gate.onFail;
+
+  const reasons = [
+    `Evidence coverage ${Math.round(rubricScores.evidenceUse * 100)}%`,
+    `Actionability ${Math.round(rubricScores.actionability * 100)}%`,
+    `Gate ${Math.round(testCase.gate.minimumScore * 100)}% ${passed ? "passed" : "missed"}`,
+  ];
+  if (gateOutcome !== "PASS") reasons.push(`${gateOutcome} because this case protects ${testCase.kind.toLowerCase().replace(/_/g, " ")} quality`);
+  if (testCase.gate.highRisk) reasons.push("High-risk intelligence change");
+
+  return {
+    caseId: testCase.id,
+    title: testCase.title,
+    kind: testCase.kind,
+    score: Number(score.toFixed(3)),
+    passed,
+    gateOutcome,
+    reasons,
+    rubricScores,
+    output: {
+      confidence: replay.confidence,
+      summary: replay.summary,
+      evidenceIds: replay.selectedEvidence.map((record) => record.id),
+      nextActions: replay.nextActions,
+    },
+  };
+}
+
+function strongestGateOutcome(results: EvaluationCaseResult[]) {
+  if (results.some((result) => result.gateOutcome === "BLOCK")) return "BLOCK";
+  if (results.some((result) => result.gateOutcome === "REVIEW_REQUIRED")) return "REVIEW_REQUIRED";
+  if (results.some((result) => result.gateOutcome === "ADVISORY")) return "ADVISORY";
+  return "PASS";
+}
+
+export function runEvaluationSuite(variant: EvaluationVariant = {}): EvaluationRun {
+  const suiteId = "intelligence-quality-v1";
+  const label = variant.label || "baseline";
+  const cases = SEEDED_EVALUATION_CASES.map((testCase) => evaluateCase(testCase, variant));
+  const failedCases = cases.filter((result) => !result.passed);
+  const aggregateScore = cases.reduce((sum, result) => sum + result.score, 0) / cases.length;
+  const passRate = cases.filter((result) => result.passed).length / cases.length;
+  const gateOutcome = strongestGateOutcome(cases);
+
+  return {
+    runId: `${suiteId}:${label}:${new Date().toISOString()}`,
+    suiteId,
+    label,
+    generatedAt: new Date().toISOString(),
+    aggregateScore: Number(aggregateScore.toFixed(3)),
+    passRate: Number(passRate.toFixed(3)),
+    passed: gateOutcome === "PASS",
+    gateOutcome,
+    cases,
+    failedCases,
+    trends: {
+      totalCases: cases.length,
+      passedCases: cases.length - failedCases.length,
+      highRiskFailures: failedCases.filter((result) => SEEDED_EVALUATION_CASES.find((testCase) => testCase.id === result.caseId)?.gate.highRisk).length,
+      advisoryFailures: failedCases.filter((result) => result.gateOutcome === "ADVISORY").length,
+    },
+  };
+}
+
+export function compareEvaluationVariants(candidate: EvaluationVariant = {}): EvaluationComparison {
+  const baseline = runEvaluationSuite({ label: "current-baseline", evidenceStrictness: "baseline", confidencePolicy: "baseline" });
+  const candidateRun = runEvaluationSuite({
+    label: candidate.label || "candidate-strict-gate",
+    evidenceStrictness: candidate.evidenceStrictness || "strict",
+    confidencePolicy: candidate.confidencePolicy || "risk_averse",
+    actionabilityBoost: candidate.actionabilityBoost ?? 8,
+  });
+  const regressedCases = candidateRun.cases
+    .map((result) => {
+      const baselineCase = baseline.cases.find((item) => item.caseId === result.caseId);
+      return {
+        caseId: result.caseId,
+        title: result.title,
+        baselineScore: baselineCase?.score ?? 0,
+        candidateScore: result.score,
+      };
+    })
+    .filter((item) => item.candidateScore + 0.02 < item.baselineScore);
+  const improvedCases = candidateRun.cases
+    .map((result) => {
+      const baselineCase = baseline.cases.find((item) => item.caseId === result.caseId);
+      return {
+        caseId: result.caseId,
+        title: result.title,
+        baselineScore: baselineCase?.score ?? 0,
+        candidateScore: result.score,
+      };
+    })
+    .filter((item) => item.candidateScore > item.baselineScore + 0.02);
+  const status = candidateRun.gateOutcome;
+
+  return {
+    baseline,
+    candidate: candidateRun,
+    delta: Number((candidateRun.aggregateScore - baseline.aggregateScore).toFixed(3)),
+    regressedCases,
+    improvedCases,
+    promotionGate: {
+      status,
+      reason: status === "PASS"
+        ? "Candidate passes all seeded advisory and high-risk gates."
+        : "Candidate needs review before promotion because one or more seeded intelligence quality gates failed.",
+    },
+  };
+}

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -37,6 +37,7 @@ export async function getCompanyObservabilitySnapshot(companyId: string) {
   const failedJobs = activeJobs.filter((job) => job.status === "FAILED").length;
   const runningJobs = activeJobs.filter((job) => job.status === "RUNNING").length;
   const criticalAlert = scoreHealth?.alerts?.find((alert: any) => alert.severity === "CRITICAL") ?? null;
+  const evaluationFailures = recentEvents.filter((event) => event.outcomeType === "EVAL_GATE_FAILED");
 
   return {
     guardianHeartbeat,
@@ -50,7 +51,12 @@ export async function getCompanyObservabilitySnapshot(companyId: string) {
     recommendedActions: {
       escalateScoreRepair: Boolean(criticalAlert || scoreHealth?.overallBand === "SUSPICIOUS"),
       recoverFailedJobs: failedJobs > 0,
+      reviewEvaluationFailures: evaluationFailures.length > 0,
       syncQueue: true,
+    },
+    evaluation: {
+      recentFailures: evaluationFailures,
+      failedGateCount: evaluationFailures.length,
     },
     workerReports,
     recentEvents,

--- a/src/lib/scoring-contract.d.ts
+++ b/src/lib/scoring-contract.d.ts
@@ -1,6 +1,16 @@
 export const SCORE_MIN: number;
 export const SCORE_MAX: number;
 export const KNOWLEDGE_ICE_DIVISOR: number;
+export const PRIORITY_SCORE_MAX: number;
+export const PRIORITY_WEIGHTS: Readonly<{
+  ice: number;
+  quality: number;
+  urgency: number;
+  freshness: number;
+  human: number;
+  risk: number;
+}>;
+export const PRIORITY_STATE_MULTIPLIERS: Readonly<Record<string, number>>;
 
 export type CanonicalTripletInput = {
   impact?: number | null;
@@ -15,15 +25,53 @@ export type CanonicalTripletInput = {
   kind?: string | null;
   evidence?: unknown;
   hashtags?: string[] | null;
+  iceScore?: number | null;
+  qualityScore?: number | null;
+  urgencyScore?: number | null;
+  freshnessScore?: number | null;
+  feedbackScore?: number | null;
+  candidateState?: string | null;
+  activityState?: string | null;
+  processingStatus?: string | null;
+  sortOrder?: number | null;
+  controlMode?: string | null;
+  updatedAt?: Date | string | null;
+  createdAt?: Date | string | null;
+  rottenAt?: Date | string | null;
+  freshnessWindowDays?: number | null;
+  memoryMultiplier?: number | null;
+  _memoryMultiplier?: number | null;
+  priorityIceMax?: number | null;
 };
 
 export function clampMetric(value: number | null | undefined, min?: number, max?: number): number;
+export function clampUnit(value: number | null | undefined, fallback?: number): number;
 export function normalizeScoreTriplet(
   input?: CanonicalTripletInput,
   aliases?: CanonicalTripletInput,
 ): { impact: number; confidence: number; effort: number };
 export function calculateTaskIceScore(input?: CanonicalTripletInput): number;
 export function calculateKnowledgeIceScore(input?: CanonicalTripletInput): number;
+export function normalizeIceSignal(iceScore?: number | null, maxScore?: number): number;
+export function computeImpliedFreshnessSignal(input?: CanonicalTripletInput): number;
+export function computeHumanPrioritySignal(input?: CanonicalTripletInput): number;
+export function computeRiskPrioritySignal(input?: CanonicalTripletInput): number;
+export function computeBlendedPriorityProfile(input?: CanonicalTripletInput): {
+  score: number;
+  manualAnchor: boolean;
+  stateMultiplier: number;
+  memoryMultiplier: number;
+  components: {
+    ice: number;
+    quality: number;
+    urgency: number;
+    freshness: number;
+    human: number;
+    risk: number;
+  };
+  weights: typeof PRIORITY_WEIGHTS;
+  reasons: string[];
+};
 export function normalizeTaskScores(input?: CanonicalTripletInput): {
   impact: number;
   confidence: number;

--- a/src/lib/scoring-contract.js
+++ b/src/lib/scoring-contract.js
@@ -32,6 +32,20 @@ const COMPLEXITY_KEYWORDS = [
   "prototype",
   "experiment",
 ];
+const PRIORITY_SCORE_MAX = 1000;
+const PRIORITY_WEIGHTS = Object.freeze({
+  ice: 0.36,
+  quality: 0.20,
+  urgency: 0.16,
+  freshness: 0.12,
+  human: 0.10,
+  risk: 0.06,
+});
+const PRIORITY_STATE_MULTIPLIERS = Object.freeze({
+  EVALUATED: 1,
+  REFINED: 0.86,
+  GENERATED: 0.72,
+});
 
 function clampMetric(value, min = SCORE_MIN, max = SCORE_MAX) {
   const numeric = Number(value);
@@ -77,6 +91,124 @@ function calculateTaskIceScore(input = {}) {
 function calculateKnowledgeIceScore(input = {}) {
   const { impact, confidence, effort } = normalizeScoreTriplet(input);
   return Number(((impact * confidence * effort) / KNOWLEDGE_ICE_DIVISOR).toFixed(1));
+}
+
+function clampUnit(value, fallback = 0) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return Math.max(0, Math.min(1, fallback));
+  }
+  return Math.max(0, Math.min(1, numeric));
+}
+
+function normalizeIceSignal(iceScore, maxScore = PRIORITY_SCORE_MAX) {
+  const numeric = Number(iceScore);
+  if (!Number.isFinite(numeric) || numeric <= 0) return 0;
+  return clampUnit(numeric / maxScore);
+}
+
+function computeImpliedFreshnessSignal(input = {}) {
+  if (input.freshnessScore !== null && input.freshnessScore !== undefined) {
+    return clampUnit(input.freshnessScore);
+  }
+
+  const rawDate = input.updatedAt ?? input.createdAt;
+  const timestamp = rawDate ? new Date(rawDate).getTime() : Date.now();
+  if (!Number.isFinite(timestamp)) return 0.5;
+
+  const windowDays = Number.isFinite(Number(input.freshnessWindowDays))
+    ? Math.max(1, Number(input.freshnessWindowDays))
+    : 30;
+  const ageMs = Math.max(0, Date.now() - timestamp);
+  const windowMs = windowDays * 24 * 60 * 60 * 1000;
+  return Math.max(0.1, clampUnit(1 - ageMs / windowMs));
+}
+
+function computeHumanPrioritySignal(input = {}) {
+  const feedbackScore = Number(input.feedbackScore ?? 0);
+  const feedbackSignal = feedbackScore > 0
+    ? Math.min(1, 0.55 + feedbackScore * 0.08)
+    : feedbackScore < 0
+      ? Math.max(0, 0.45 + feedbackScore * 0.08)
+      : 0.5;
+  const manualAnchorSignal = Number(input.sortOrder ?? 0) < 0 ? 1 : 0;
+  const humanGuidedSignal = String(input.controlMode || "").toUpperCase() === "HUMAN_GUIDED" ? 0.85 : 0;
+  return clampUnit(Math.max(feedbackSignal, manualAnchorSignal, humanGuidedSignal));
+}
+
+function computeRiskPrioritySignal(input = {}) {
+  const confidence = clampMetric(input.confidenceScore ?? input.confidence ?? 5);
+  const activityState = String(input.activityState || "").toUpperCase();
+  const processingStatus = String(input.processingStatus || "").toUpperCase();
+  const rottenAt = input.rottenAt ? new Date(input.rottenAt).getTime() : null;
+  let risk = 0.25;
+
+  if (activityState === "STALE" || activityState === "EXPIRED") risk += 0.2;
+  if (processingStatus === "REVIEW" || processingStatus === "DECLINED") risk += 0.18;
+  if (Number.isFinite(rottenAt) && rottenAt < Date.now()) risk += 0.2;
+  if (confidence <= 4) risk += 0.16;
+  if (confidence >= 8) risk -= 0.08;
+
+  return clampUnit(risk);
+}
+
+function describePriorityBand(value, high, medium, label) {
+  if (value >= high) return `${label}:high`;
+  if (value >= medium) return `${label}:medium`;
+  return `${label}:low`;
+}
+
+function computeBlendedPriorityProfile(input = {}) {
+  const iceSignal = normalizeIceSignal(input.iceScore, input.priorityIceMax ?? PRIORITY_SCORE_MAX);
+  const qualitySignal = clampUnit(input.qualityScore, iceSignal);
+  const urgencySignal = clampUnit(
+    input.urgencyScore,
+    clampMetric(input.impact ?? 5) / SCORE_MAX,
+  );
+  const freshnessSignal = computeImpliedFreshnessSignal(input);
+  const humanSignal = computeHumanPrioritySignal(input);
+  const riskSignal = computeRiskPrioritySignal(input);
+  const stateMultiplier =
+    PRIORITY_STATE_MULTIPLIERS[String(input.candidateState || "").toUpperCase()] ?? 0.78;
+  const rawMemoryMultiplier = Number(input.memoryMultiplier ?? input._memoryMultiplier ?? 1);
+  const boundedMemoryMultiplier = Number.isFinite(rawMemoryMultiplier)
+    ? Math.max(0.6, Math.min(1.4, rawMemoryMultiplier))
+    : 1;
+  const weighted =
+    iceSignal * PRIORITY_WEIGHTS.ice +
+    qualitySignal * PRIORITY_WEIGHTS.quality +
+    urgencySignal * PRIORITY_WEIGHTS.urgency +
+    freshnessSignal * PRIORITY_WEIGHTS.freshness +
+    humanSignal * PRIORITY_WEIGHTS.human +
+    riskSignal * PRIORITY_WEIGHTS.risk;
+  const score = Number((weighted * stateMultiplier * boundedMemoryMultiplier * PRIORITY_SCORE_MAX).toFixed(2));
+  const manualAnchor = Number(input.sortOrder ?? 0) < 0;
+
+  return {
+    score,
+    manualAnchor,
+    stateMultiplier,
+    memoryMultiplier: boundedMemoryMultiplier,
+    components: {
+      ice: Number(iceSignal.toFixed(3)),
+      quality: Number(qualitySignal.toFixed(3)),
+      urgency: Number(urgencySignal.toFixed(3)),
+      freshness: Number(freshnessSignal.toFixed(3)),
+      human: Number(humanSignal.toFixed(3)),
+      risk: Number(riskSignal.toFixed(3)),
+    },
+    weights: PRIORITY_WEIGHTS,
+    reasons: [
+      describePriorityBand(iceSignal, 0.7, 0.35, "ice"),
+      describePriorityBand(qualitySignal, 0.75, 0.45, "quality"),
+      describePriorityBand(urgencySignal, 0.75, 0.45, "urgency"),
+      describePriorityBand(freshnessSignal, 0.75, 0.35, "freshness"),
+      describePriorityBand(humanSignal, 0.8, 0.55, "human-signal"),
+      describePriorityBand(riskSignal, 0.65, 0.35, "risk"),
+      manualAnchor ? "manual-anchor:preserved" : "manual-anchor:none",
+      `state:${String(input.candidateState || "UNKNOWN").toLowerCase()}`,
+    ],
+  };
 }
 
 function normalizeTaskScores(input = {}) {
@@ -266,10 +398,19 @@ module.exports = {
   SCORE_MIN,
   SCORE_MAX,
   KNOWLEDGE_ICE_DIVISOR,
+  PRIORITY_SCORE_MAX,
+  PRIORITY_WEIGHTS,
+  PRIORITY_STATE_MULTIPLIERS,
   clampMetric,
+  clampUnit,
   normalizeScoreTriplet,
   calculateTaskIceScore,
   calculateKnowledgeIceScore,
+  normalizeIceSignal,
+  computeImpliedFreshnessSignal,
+  computeHumanPrioritySignal,
+  computeRiskPrioritySignal,
+  computeBlendedPriorityProfile,
   normalizeTaskScores,
   normalizeKnowledgeScores,
   normalizeGoalScores,


### PR DESCRIPTION
## Summary

- Implements #164 blended tactical priority scoring across the shared scoring contract, NBA/frontier ordering, tactical API, and tactical board explanations.
- Implements #172 advisory recommendation/agent evaluation bench with seeded synthetic fixtures, authenticated API, operator page, promotion-gate metadata, and Observability failure publication.
- Implements #54 content generation with tone-aware email subjects, platform ad copy, social posts, landing-page copy, CreativeDraft persistence, audit/generation events, nav entry, and dashboard counts.
- Updates README, HANDOVER, SSOT, system design, rulebook, and local AI pipeline docs for the new contracts.

## Validation

- node scoring smoke
- node evaluation-bench smoke
- node content-generation smoke
- npm run audit:docs
- npm run audit:semantic
- npm run lint
- npx tsc --noEmit
- Local browser route smoke reached the new authenticated routes and confirmed login gating; authenticated visual QA remains blocked by the local browser session lacking login.

## Notes

- Draft PR because the local browser session cannot authenticate for full visual QA.
- tsconfig.tsbuildinfo was generated by TypeScript verification and intentionally left out of the commit.
