### PR TITLE
Add AI workload budget governor

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -32,7 +32,7 @@ Read first:
 - the webapp now exposes `Search & Answers`, `Observability`, and `Workflows` as first implementation slices for the next ideabank wave
 - `Search & Answers` now supports entity filters, result counts, and grounded-answer confidence/evidence grouping
 - first-class entity search results now open the canonical shared `/card/[uuid]` detail route rather than only module landing pages
-- `Observability` now supports bounded queue repair actions directly from the webapp mission-control surface
+- `Observability` now supports bounded queue repair actions and AI workload budget controls directly from the webapp mission-control surface
 - workflow blueprints and enrichment waterfall policies are persisted system contracts, not local page-only state
 - active workflow blueprints now become first-class `PipelineJob` records that the worker can claim and execute
 - enrichment waterfall policy now influences runtime URL-intelligence provider selection for product and competitor research paths
@@ -40,6 +40,8 @@ Read first:
 - evaluation runs use synthetic fixtures by default and only write to Observability when an operator explicitly publishes failed gates
 - the webapp now exposes `Content Generation` for producing email subject lines, ad copy, social posts, and landing-page copy from existing company, product, goal, topic, and competitor context
 - content generation persists outputs as `CreativeDraft` records and records generation/audit events without automated posting
+- AI workload governance now persists `AiWorkloadUsage`, `BudgetPolicy`, and `BudgetEvent` records so queue, evaluation, content-generation, and observability work can be attributed by company and feature
+- budget controls are operator-applied and reviewable: queue throttling, evaluation batching, and cache/reuse policy changes do not silently suppress critical evidence work
 - the webapp now exposes `Athlete App` beside the coach/operator surfaces so athletes can see coach-assigned checklist work, record daily activity, wellness/body metrics, and mark assigned work complete
 - the webapp also exposes `Athletes` as the coach-facing records view for team daily logs, completion evidence, readiness, load, sleep, soreness, and pain flags
 - athlete records persist as `AthleteActivityLog` entries keyed by company, athlete email, day, and optional assigned task
@@ -123,5 +125,6 @@ The work is not done until:
 - Frontier recompute assigns tactical columns by blended priority thresholds, not raw ICE alone, while preserving manual human drag/drop anchors.
 - Evaluation bench replay is advisory first: synthetic fixtures and rubric gates compare baseline vs candidate behavior without production writes unless failed gates are explicitly published to Observability.
 - Content generation is draft-only: it can create and persist channel-specific copy, but it must not post externally or generate images in the first release.
+- Budget governor is observability-first: usage/cost values are estimates unless explicitly marked actual, and controls are recorded as events/policies rather than hidden scheduling overrides.
 - Athlete app is athlete-facing: it records daily activity, wellness/body metrics, and completion evidence but does not replace the coach/operator planning surfaces.
 - Athlete records is coach-facing: it can summarize team submissions, but planning and assignment still stay in the coach/operator checklist surfaces.

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ New operator surfaces:
 - `/:companyId/search` provides unified internal retrieval plus grounded answers over company context
 - Search now supports entity-layer filters, ranked counts, and grounded-answer confidence/evidence-group framing
 - first-class entity search results now deep-link into the canonical shared `/card/[uuid]` card route instead of dropping operators onto module-level index pages
-- `/:companyId/observability` provides mission-control visibility into worker health, queue pressure, score health, and recent outcomes
-- Observability now exposes bounded repair actions for queue sync, score-repair escalation, and failed-job recovery
+- `/:companyId/observability` provides mission-control visibility into worker health, queue pressure, score health, AI workload budget pressure, and recent outcomes
+- Observability now exposes bounded repair and budget actions for queue sync, score-repair escalation, failed-job recovery, queue throttling, evaluation batching, and cache/reuse controls
 - `/:companyId/workflows` provides bounded workflow blueprints and enrichment-waterfall policy management
 - active workflow blueprints are not passive records: they materialize into claimable `WORKFLOW_BLUEPRINT` queue jobs and execute through the shared worker queue
 - enrichment-waterfall policies now affect runtime provider selection for URL intelligence instead of living as config-only records

--- a/docs/LOCAL_AI_PIPELINE.md
+++ b/docs/LOCAL_AI_PIPELINE.md
@@ -393,6 +393,17 @@ The first athlete app contract is a daily recording loop beside the coach/operat
 - completed assigned work writes audit/outcome events and archives the linked checklist item as completed
 - wearable integrations, medical claims, public sharing, and payment flows are out of scope for this first slice
 
+## Budget governor
+
+The first AI workload budget-governor slice is an observability-first control loop:
+
+- `AiWorkloadUsage` records estimated workload units, runtime, retries, request counts, and cost dimensions for queue jobs, evaluation replays, content generation, and observability actions
+- `BudgetPolicy` records per-company feature thresholds and explicit controls such as throttle, batch, cache/reuse, review-required, or pause
+- `BudgetEvent` records reviewable budget pressure and applied controls with evidence and value assessment
+- the pipeline queue records usage on completed and failed queue jobs so retry storms and high-value work can be separated
+- evaluation and content-generation APIs record usage when operators run those surfaces
+- Observability shows budget pressure, usage by feature, recommendations, and bounded controls without silently overriding human-guided scheduling or critical safety/evidence work
+
 ## Delivery modes
 
 There is one supported hosted execution mode:

--- a/docs/RULEBOOK.md
+++ b/docs/RULEBOOK.md
@@ -214,6 +214,14 @@ Content generation rules:
 - generated copy must be persisted as `CreativeDraft` records and must remain editable outside the generator
 - content generation must record audit/generation events so future feedback loops can distinguish draft creation from campaign performance
 
+Budget governor rules:
+
+- AI workload usage must be attributed by company and feature before it is used for budget pressure or controls
+- estimated cost, workload units, retries, external requests, and runtime must remain visibly distinguishable from actual invoiced provider spend
+- budget controls must be explicit operator-applied policies or events; they must not silently suppress critical evidence, safety, evaluation, or human-guided queue work
+- budget events must distinguish high-cost high-value work from likely waste such as retry storms, repeated failed jobs, or low-value repeated generation
+- Observability is the first budget-governor surface; budget controls must stay bounded to throttle, batch, cache/reuse, review-required, or pause policies until the system has stronger outcome evidence
+
 Athlete app rules:
 
 - athlete-facing recording must be separate from coach/operator planning surfaces while reusing the same company membership boundary

--- a/docs/SSOT.md
+++ b/docs/SSOT.md
@@ -95,14 +95,15 @@ The current intelligence-operations contract also includes:
 - one blended tactical priority profile that keeps ICE visible while ranking work through explainable ICE, quality, urgency, freshness, human-signal, risk, lifecycle-state, and memory inputs
 - one grounded answer layer over company context using explicit evidence objects
 - grounded answers now expose intent, confidence, and evidence-group framing as first-class contract fields
-- one observability surface for worker health, queue pressure, score-health, and recent outcomes
-- observability also owns bounded repair actions for queue sync, score-repair escalation, and failed-job recovery
+- one observability surface for worker health, queue pressure, score-health, AI workload budget pressure, and recent outcomes
+- observability also owns bounded repair and budget actions for queue sync, score-repair escalation, failed-job recovery, queue throttling, evaluation batching, and cache/reuse controls
 - persisted workflow blueprints for bounded automation building, materialized as real worker-queue jobs when active
 - persisted enrichment waterfall policies for provider ordering and fallback governance, applied at runtime during URL intelligence enrichment
 - one advisory evaluation bench for replaying seeded synthetic intelligence cases before recommendation, grounded-answer, ranking, workflow, and data-readiness changes are promoted
 - evaluation failures can be explicitly published into Observability as `EVAL_GATE_FAILED` outcome events; normal replay does not mutate production company data
 - one content-generation surface that turns existing company, product, goal, topic, and competitor context into saved `CreativeDraft` records for email subjects, ads, social posts, and landing-page copy
 - content generation is draft-only in the current contract: no automated posting, no image generation, and no multi-language generation
+- one AI workload budget-governor layer that persists `AiWorkloadUsage`, `BudgetPolicy`, and `BudgetEvent` records for company/feature attribution, estimated cost, workload units, retry pressure, reviewable budget events, and explicit operator-applied controls
 - one athlete-facing daily app beside the coach/operator app, backed by `AthleteActivityLog`, where athletes can see assigned checklist work, record activity, readiness, intensity, sleep, soreness, stress, mood, hydration, body weight, pain/nutrition notes, and completion evidence
 - one coach-facing athlete records view where admins can review team daily submissions, completion evidence, load, readiness, sleep, soreness, and pain flags
 - completing coach-assigned work from the athlete app records an athlete outcome and archives the assigned checklist item as completed

--- a/docs/SYSTEM_DESIGN_LLD.md
+++ b/docs/SYSTEM_DESIGN_LLD.md
@@ -121,6 +121,7 @@ The repetitive-job system now has a first-class queue model:
 - `internal-search.ts` also owns result counts, entity-layer filtering, and ranking boosts from ICE and freshness
 - `grounded-answers.ts` builds bounded evidence-backed answers on top of the internal search layer, including explicit intent/confidence/evidence-group fields
 - `observability.ts` aggregates heartbeat, queue, score-health, worker reports, and recent outcomes for mission-control surfaces, and drives bounded repair recommendations
+- `budget-governor.ts` owns workload usage attribution, virtual/default budget policies, budget-pressure summaries, recommended budget events, and explicit control application for queue/evaluation/content/observability work
 - `workflow-blueprints.ts` owns the persisted bounded workflow-builder contract and default blueprint registry; active blueprints are synchronized into `PipelineJob` records and executed by the shared queue worker
 - `enrichment-waterfall.ts` owns the persisted provider-ordering and fallback policy contract for enrichment governance, and `url-enrichment.ts` consumes that policy at runtime for product/competitor research
 
@@ -156,3 +157,13 @@ The repetitive-job system now has a first-class queue model:
 - `/:companyId/athlete` is the athlete-facing surface for coach-assigned work, activity recording, wellness/body metrics, readiness notes, pain/nutrition notes, and completion evidence
 - `/:companyId/athletes` is the coach-facing records surface for team daily submissions, load, completion evidence, readiness, sleep, soreness, and pain flags
 - completing assigned work from the athlete app records an audit/outcome event and moves the linked checklist item to completed/archived state
+
+## 13. Budget Governor Architecture
+
+- `AiWorkloadUsage` stores company/feature attribution for queue jobs, evaluation replays, content-generation runs, observability actions, and future model/provider calls
+- `BudgetPolicy` stores per-company feature controls and thresholds for estimated daily cost, workload units, retries, external requests, and control mode
+- `BudgetEvent` stores reviewable budget pressure, anomaly, and control-application events with evidence and value assessment
+- budget values are estimated by default and must remain visibly distinct from actual provider spend
+- queue worker completion/failure, evaluation POSTs, content-generation POSTs, and observability actions all record workload usage in the first slice
+- Observability renders budget pressure, workload attribution, recommended budget events, and bounded controls for throttling queue work, batching evaluations, and cache/reuse policy
+- budget controls must not silently erase human-guided queue ordering or suppress critical evidence/safety work

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,9 @@ model Company {
   citationSnapshots    CitationSnapshot[]
   workflowBlueprints   WorkflowBlueprint[]
   enrichmentPolicies   EnrichmentWaterfallPolicy[]
+  aiWorkloadUsages     AiWorkloadUsage[]
+  budgetPolicies       BudgetPolicy[]
+  budgetEvents         BudgetEvent[]
   
   // Profile Validation Fields
   website             String?
@@ -618,6 +621,77 @@ model PipelineJob {
   @@index([companyId, queueColumn, manualSortOrder])
   @@index([companyId, status, controlMode, priorityScore])
   @@index([status, queueColumn, priorityScore, updatedAt])
+}
+
+model AiWorkloadUsage {
+  id                  String   @id @default(uuid()) @map("_id")
+  companyId           String
+  feature             String
+  jobType             String?
+  provider            String?  @default("local")
+  modelName           String?
+  entityType          String?  @default("SYSTEM")
+  entityId            String?
+  usageKind           String   @default("ESTIMATED")
+  status              String   @default("RECORDED")
+  workloadUnits       Float    @default(1)
+  runtimeMs           Int      @default(0)
+  localComputeMs      Int      @default(0)
+  inputTokens         Int      @default(0)
+  outputTokens        Int      @default(0)
+  externalRequests    Int      @default(0)
+  retryCount          Int      @default(0)
+  estimatedCostMicros Int      @default(0)
+  actualCostMicros    Int?
+  valueSignal         String?  @default("UNKNOWN")
+  metadata            Json?    @default("{}")
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @default(now()) @updatedAt
+  company             Company  @relation(fields: [companyId], references: [id], onDelete: Cascade)
+
+  @@index([companyId, feature, createdAt])
+  @@index([companyId, jobType, createdAt])
+  @@index([companyId, usageKind, createdAt])
+}
+
+model BudgetPolicy {
+  id                      String   @id @default(uuid()) @map("_id")
+  companyId               String
+  feature                 String
+  status                  String   @default("ACTIVE")
+  dailyEstimatedCostMicros Int     @default(250000)
+  dailyWorkloadUnitsLimit Float    @default(100)
+  retryLimit              Int      @default(5)
+  externalRequestLimit    Int      @default(50)
+  controlMode             String   @default("MONITOR")
+  controls                Json?    @default("{}")
+  createdAt               DateTime @default(now())
+  updatedAt               DateTime @default(now()) @updatedAt
+  company                 Company  @relation(fields: [companyId], references: [id], onDelete: Cascade)
+
+  @@unique([companyId, feature])
+  @@index([companyId, status, updatedAt])
+}
+
+model BudgetEvent {
+  id                  String   @id @default(uuid()) @map("_id")
+  companyId           String
+  feature             String
+  eventType           String
+  severity            String   @default("INFO")
+  status              String   @default("OPEN")
+  recommendation      String
+  valueAssessment     String   @default("UNKNOWN")
+  evidence            Json?    @default("{}")
+  appliedControl      String?
+  actorEmail          String?
+  resolvedAt          DateTime?
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @default(now()) @updatedAt
+  company             Company  @relation(fields: [companyId], references: [id], onDelete: Cascade)
+
+  @@index([companyId, status, severity, createdAt])
+  @@index([companyId, feature, createdAt])
 }
 
 model WorkflowBlueprint {

--- a/scripts/lib/pipeline-jobs.js
+++ b/scripts/lib/pipeline-jobs.js
@@ -105,14 +105,50 @@ async function executePipelineJob(prisma, job) {
   }
 }
 
+function estimatePipelineJobCostMicros({ workloadUnits, runtimeMs, retryCount }) {
+  return Math.max(0, Math.round((workloadUnits || 1) * 2500 + (runtimeMs || 0) * 2 + (retryCount || 0) * 1000));
+}
+
+async function recordPipelineJobUsage(prisma, job, input) {
+  if (!prisma.aiWorkloadUsage) return null;
+  const workloadUnits = Math.max(0.1, Number(input.workloadUnits || 1));
+  const runtimeMs = Math.max(0, Math.round(Number(input.runtimeMs || 0)));
+  const retryCount = Math.max(0, Math.round(Number(input.retryCount || 0)));
+  return prisma.aiWorkloadUsage.create({
+    data: {
+      companyId: job.companyId,
+      feature: "pipeline-queue",
+      jobType: job.jobType,
+      provider: "local-worker",
+      entityType: job.entityType || "COMPANY",
+      entityId: job.entityId || job.companyId,
+      usageKind: "ESTIMATED",
+      workloadUnits,
+      runtimeMs,
+      localComputeMs: runtimeMs,
+      retryCount,
+      estimatedCostMicros: estimatePipelineJobCostMicros({ workloadUnits, runtimeMs, retryCount }),
+      valueSignal: input.valueSignal || "QUEUE_WORK",
+      metadata: {
+        status: input.status,
+        queueColumn: job.queueColumn,
+        controlMode: job.controlMode,
+        reason: input.reason || null,
+      },
+    },
+  });
+}
+
 async function runPipelineQueueBatch(prisma, limit = 3) {
   await syncAllCompanyPipelineJobs(prisma);
   const claimed = await claimNextPipelineJobs(prisma, limit);
   let executed = 0;
 
   for (const job of claimed) {
+    const startedAt = Date.now();
     try {
       const result = await executePipelineJob(prisma, job);
+      const workloadUnits = typeof result === "number" ? Math.max(1, result) : 1;
       await completePipelineJob(
         prisma,
         job.id,
@@ -120,10 +156,26 @@ async function runPipelineQueueBatch(prisma, limit = 3) {
           ? `${job.jobType} completed with ${result} operation(s).`
           : `${job.jobType} completed successfully.`,
       );
+      await recordPipelineJobUsage(prisma, job, {
+        status: "COMPLETED",
+        workloadUnits,
+        runtimeMs: Date.now() - startedAt,
+        retryCount: job.attemptCount || 0,
+        valueSignal: workloadUnits > 0 ? "QUEUE_WORK_COMPLETED" : "NO_OP",
+        reason: typeof result === "number" ? `${result} operation(s)` : "completed",
+      });
       executed += 1;
     } catch (error) {
       console.error(`[PIPELINE QUEUE] ${job.jobType} failed for ${job.company?.name ?? job.companyId}:`, error.message);
       await failPipelineJob(prisma, job.id, error);
+      await recordPipelineJobUsage(prisma, job, {
+        status: "FAILED",
+        workloadUnits: 1,
+        runtimeMs: Date.now() - startedAt,
+        retryCount: (job.attemptCount || 0) + 1,
+        valueSignal: "RETRY_WASTE_RISK",
+        reason: error.message,
+      });
     }
   }
 

--- a/src/app/[companyId]/observability/page.tsx
+++ b/src/app/[companyId]/observability/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { Badge, Button, Group, Loader, SimpleGrid, Stack, Table } from "@mantine/core";
-import { IconActivity as Activity, IconAlertTriangle as AlertTriangle, IconHeartbeat as Heartbeat, IconListCheck as ListCheck, IconRefresh as RefreshIcon, IconStethoscope as Stethoscope } from "@tabler/icons-react";
+import { IconActivity as Activity, IconAlertTriangle as AlertTriangle, IconCoins as Coins, IconGauge as Gauge, IconHeartbeat as Heartbeat, IconListCheck as ListCheck, IconRefresh as RefreshIcon, IconStethoscope as Stethoscope } from "@tabler/icons-react";
 import { MetricCard, Notice, PageHeader, PageShell } from "@/components/ui/app-shell";
 import { BodyText, MetaText } from "@/components/ui/typography";
 import { UnifiedCard, UnifiedCardBody, UnifiedCardHeader } from "@/components/ui/unified-card";
@@ -59,6 +59,7 @@ export default function ObservabilityPage() {
   const heartbeat = data?.guardianHeartbeat || {};
   const queue = data?.queue || { jobs: [] };
   const scoreHealth = data?.scoreHealth || null;
+  const budget = data?.budget || { pressure: "UNKNOWN", usageByFeature: [], openEvents: [], recommendations: [] };
 
   return (
     <PageShell width="full">
@@ -72,6 +73,7 @@ export default function ObservabilityPage() {
         <MetricCard icon={Activity} color="checklist" label="Worker Alive" value={heartbeat.workerAlive ? "Yes" : "No"} detail={heartbeat.lastProgressAt || "—"} />
         <MetricCard icon={ListCheck} color="strategy" label="Active Queue Jobs" value={queue.totalActiveJobs ?? 0} detail={`${queue.runningJobs ?? 0} running`} />
         <MetricCard icon={AlertTriangle} color="knowmore" label="Score Health" value={scoreHealth?.overallBand || "UNKNOWN"} detail={`${scoreHealth?.alerts?.length ?? 0} active alerts`} />
+        <MetricCard icon={Coins} color="tactical" label="Budget Pressure" value={budget.pressure || "UNKNOWN"} detail={`$${budget.totalEstimatedCost ?? 0} est · ${budget.totalWorkloadUnits ?? 0} units`} />
       </SimpleGrid>
 
       {scoreHealth?.alerts?.length ? (
@@ -117,6 +119,65 @@ export default function ObservabilityPage() {
         </UnifiedCardBody>
       </UnifiedCard>
 
+      <UnifiedCard tone="tactical">
+        <UnifiedCardHeader
+          title="Budget Governor"
+          supporting={<Badge variant="light" color="tactical">{budget.windowHours || 24}h window</Badge>}
+        />
+        <UnifiedCardBody>
+          <Stack gap="md">
+            <SimpleGrid cols={{ base: 1, md: 3 }} spacing="sm">
+              <Button
+                leftSection={<Gauge size={16} />}
+                variant="light"
+                color="tactical"
+                loading={actionLoading === "BUDGET_THROTTLE_QUEUE"}
+                onClick={() => void runAction("BUDGET_THROTTLE_QUEUE")}
+              >
+                Throttle Queue
+              </Button>
+              <Button
+                leftSection={<RefreshIcon size={16} />}
+                variant="light"
+                color="strategy"
+                loading={actionLoading === "BUDGET_BATCH_EVALUATIONS"}
+                onClick={() => void runAction("BUDGET_BATCH_EVALUATIONS")}
+              >
+                Batch Evaluations
+              </Button>
+              <Button
+                leftSection={<Coins size={16} />}
+                variant="light"
+                color="knowmore"
+                loading={actionLoading === "BUDGET_CACHE_REUSE"}
+                onClick={() => void runAction("BUDGET_CACHE_REUSE")}
+              >
+                Cache / Reuse
+              </Button>
+            </SimpleGrid>
+
+            {(budget.recommendations || []).length ? (
+              <Stack gap="xs">
+                {(budget.recommendations || []).slice(0, 4).map((event: any, index: number) => (
+                  <Group key={`${event.eventType}-${index}`} justify="space-between" align="flex-start">
+                    <Stack gap={2} style={{ flex: 1 }}>
+                      <Group gap="xs">
+                        <Badge variant="light" color={event.severity === "CRITICAL" ? "review" : "tactical"}>{event.severity}</Badge>
+                        <Badge variant="outline" color="gray">{event.feature}</Badge>
+                        <Badge variant="outline" color="gray">{event.valueAssessment}</Badge>
+                      </Group>
+                      <BodyText>{event.recommendation}</BodyText>
+                    </Stack>
+                  </Group>
+                ))}
+              </Stack>
+            ) : (
+              <Notice title="Budget pressure normal">No budget anomalies detected for the current 24-hour window.</Notice>
+            )}
+          </Stack>
+        </UnifiedCardBody>
+      </UnifiedCard>
+
       <SimpleGrid cols={{ base: 1, xl: 2 }} spacing="lg">
         <UnifiedCard tone="review">
           <UnifiedCardHeader title="Active Queue Work" />
@@ -159,6 +220,34 @@ export default function ObservabilityPage() {
           </UnifiedCardBody>
         </UnifiedCard>
       </SimpleGrid>
+
+      <UnifiedCard tone="tactical">
+        <UnifiedCardHeader title="Workload Attribution" supporting={<Badge variant="light" color="tactical">{budget.usageCount || 0} records</Badge>} />
+        <UnifiedCardBody>
+          <Table highlightOnHover>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Feature</Table.Th>
+                <Table.Th>Estimated</Table.Th>
+                <Table.Th>Units</Table.Th>
+                <Table.Th>Runtime</Table.Th>
+                <Table.Th>Retries</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {(budget.usageByFeature || []).map((usage: any) => (
+                <Table.Tr key={usage.feature}>
+                  <Table.Td>{usage.feature}</Table.Td>
+                  <Table.Td>${usage.estimatedCost ?? 0}</Table.Td>
+                  <Table.Td>{Math.round((usage.workloadUnits || 0) * 10) / 10}</Table.Td>
+                  <Table.Td>{Math.round((usage.runtimeMs || 0) / 1000)}s</Table.Td>
+                  <Table.Td>{usage.retryCount || 0}</Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </UnifiedCardBody>
+      </UnifiedCard>
     </PageShell>
   );
 }

--- a/src/app/api/content-generation/route.ts
+++ b/src/app/api/content-generation/route.ts
@@ -1,6 +1,7 @@
 import { CreativeDraftType } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import { recordGenerationEvent, recordInteractionEventFromRequest } from "@/lib/audit-ledger";
+import { recordAiWorkloadUsage } from "@/lib/budget-governor";
 import { generateContentBundle, serializeContentSection, type ContentTone } from "@/lib/content-generation";
 import { prisma } from "@/lib/db";
 import { verifyMembership } from "@/lib/permissions";
@@ -124,6 +125,7 @@ export async function POST(request: NextRequest) {
 
     const tone = normalizeTone(data.tone);
     const campaignBrief = typeof data.campaignBrief === "string" ? data.campaignBrief.trim() : "";
+    const startedAt = Date.now();
     const [company, productSources, competitorSources, goals, topics, tasks] = await Promise.all([
       prisma.company.findUnique({ where: { id: companyId } }),
       prisma.source.findMany({
@@ -178,6 +180,23 @@ export async function POST(request: NextRequest) {
     const createdDrafts = await prisma.$transaction(
       draftPayloads(companyId, bundle).map((payload) => prisma.creativeDraft.create({ data: payload })),
     );
+
+    await recordAiWorkloadUsage({
+      companyId,
+      feature: "content-generation",
+      jobType: "CONTENT_GENERATION_RUN",
+      entityType: "CREATIVE_DRAFT_BUNDLE",
+      entityId: companyId,
+      workloadUnits: createdDrafts.length,
+      runtimeMs: Date.now() - startedAt,
+      outputTokens: JSON.stringify(bundle).length,
+      valueSignal: "DRAFT_CREATED",
+      metadata: {
+        tone,
+        campaignBriefPresent: Boolean(campaignBrief),
+        draftCount: createdDrafts.length,
+      },
+    });
 
     await recordInteractionEventFromRequest(request, {
       companyId,

--- a/src/app/api/evaluations/route.ts
+++ b/src/app/api/evaluations/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { recordOutcomeEvent } from "@/lib/audit-ledger";
+import { recordAiWorkloadUsage } from "@/lib/budget-governor";
 import {
   EVALUATION_SUITES,
   SEEDED_EVALUATION_CASES,
@@ -48,7 +49,23 @@ export async function POST(request: NextRequest) {
 
     const candidate = (data.candidate || {}) as EvaluationVariant;
     const persistObservability = Boolean(data.persistObservability);
+    const startedAt = Date.now();
     const comparison = compareEvaluationVariants(candidate);
+    await recordAiWorkloadUsage({
+      companyId,
+      feature: "evaluation-bench",
+      jobType: "EVALUATION_REPLAY",
+      entityType: "EVALUATION_SUITE",
+      entityId: comparison.candidate.suiteId,
+      workloadUnits: comparison.candidate.cases.length,
+      runtimeMs: Date.now() - startedAt,
+      valueSignal: comparison.candidate.failedCases.length > 0 ? "SAFETY_GATE" : "REGRESSION_CHECK",
+      metadata: {
+        aggregateScore: comparison.candidate.aggregateScore,
+        passRate: comparison.candidate.passRate,
+        failedCases: comparison.candidate.failedCases.length,
+      },
+    });
 
     if (persistObservability && comparison.candidate.failedCases.length > 0) {
       await recordOutcomeEvent({

--- a/src/app/api/observability/route.ts
+++ b/src/app/api/observability/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { verifyMembership } from "@/lib/permissions";
+import { applyBudgetControl, recordAiWorkloadUsage } from "@/lib/budget-governor";
 import { getCompanyObservabilitySnapshot } from "@/lib/observability";
 import { recordInteractionEventFromRequest, recordOutcomeEvent } from "@/lib/audit-ledger";
 import {
@@ -47,9 +48,42 @@ export async function PATCH(request: NextRequest) {
       await escalateCompanyPipelineJob(prisma as any, companyId, "SCORE_ALERT_REPAIR");
     } else if (action === "RECOVER_FAILED_JOBS") {
       await recoverFailedCompanyPipelineJobs(prisma as any, companyId);
+    } else if (action === "BUDGET_THROTTLE_QUEUE") {
+      await applyBudgetControl({
+        companyId,
+        feature: "pipeline-queue",
+        control: "THROTTLE",
+        actorEmail: auth.session.email,
+      });
+    } else if (action === "BUDGET_BATCH_EVALUATIONS") {
+      await applyBudgetControl({
+        companyId,
+        feature: "evaluation-bench",
+        control: "BATCH",
+        actorEmail: auth.session.email,
+      });
+    } else if (action === "BUDGET_CACHE_REUSE") {
+      await applyBudgetControl({
+        companyId,
+        feature: "content-generation",
+        control: "CACHE_REUSE",
+        actorEmail: auth.session.email,
+      });
     } else {
       return NextResponse.json({ error: "Unsupported action" }, { status: 400 });
     }
+
+    await recordAiWorkloadUsage({
+      companyId,
+      feature: "observability",
+      jobType: action,
+      entityType: "OBSERVABILITY_ACTION",
+      entityId: companyId,
+      workloadUnits: 1,
+      runtimeMs: 0,
+      valueSignal: action.startsWith("BUDGET_") ? "BUDGET_CONTROL" : "OPERATOR_REPAIR",
+      metadata: { action },
+    });
 
     await recordInteractionEventFromRequest(request, {
       companyId,

--- a/src/lib/budget-governor.ts
+++ b/src/lib/budget-governor.ts
@@ -1,0 +1,335 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/db";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const DEFAULT_POLICIES = [
+  { feature: "pipeline-queue", dailyEstimatedCostMicros: 250000, dailyWorkloadUnitsLimit: 120, retryLimit: 6, externalRequestLimit: 20 },
+  { feature: "content-generation", dailyEstimatedCostMicros: 200000, dailyWorkloadUnitsLimit: 80, retryLimit: 4, externalRequestLimit: 10 },
+  { feature: "evaluation-bench", dailyEstimatedCostMicros: 150000, dailyWorkloadUnitsLimit: 60, retryLimit: 3, externalRequestLimit: 5 },
+  { feature: "observability", dailyEstimatedCostMicros: 75000, dailyWorkloadUnitsLimit: 40, retryLimit: 4, externalRequestLimit: 5 },
+];
+
+type UsageInput = {
+  companyId: string;
+  feature: string;
+  jobType?: string | null;
+  provider?: string | null;
+  modelName?: string | null;
+  entityType?: string | null;
+  entityId?: string | null;
+  usageKind?: "ESTIMATED" | "ACTUAL";
+  workloadUnits?: number;
+  runtimeMs?: number;
+  localComputeMs?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  externalRequests?: number;
+  retryCount?: number;
+  estimatedCostMicros?: number;
+  actualCostMicros?: number;
+  valueSignal?: string;
+  metadata?: Record<string, unknown>;
+};
+
+function boundNumber(value: unknown, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? Math.max(0, Math.round(numeric)) : fallback;
+}
+
+export function estimateWorkloadCostMicros(input: {
+  workloadUnits?: number;
+  runtimeMs?: number;
+  externalRequests?: number;
+  retryCount?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+}) {
+  return boundNumber(
+    (input.workloadUnits ?? 1) * 2500
+      + (input.runtimeMs ?? 0) * 2
+      + (input.externalRequests ?? 0) * 1500
+      + (input.retryCount ?? 0) * 1000
+      + Math.ceil(((input.inputTokens ?? 0) + (input.outputTokens ?? 0)) / 1000) * 500,
+  );
+}
+
+export async function recordAiWorkloadUsage(input: UsageInput) {
+  const workloadUnits = Math.max(0.1, Number(input.workloadUnits ?? 1));
+  const runtimeMs = boundNumber(input.runtimeMs);
+  const externalRequests = boundNumber(input.externalRequests);
+  const retryCount = boundNumber(input.retryCount);
+  const inputTokens = boundNumber(input.inputTokens);
+  const outputTokens = boundNumber(input.outputTokens);
+  const estimatedCostMicros = boundNumber(
+    input.estimatedCostMicros,
+    estimateWorkloadCostMicros({ workloadUnits, runtimeMs, externalRequests, retryCount, inputTokens, outputTokens }),
+  );
+
+  return prisma.aiWorkloadUsage.create({
+    data: {
+      companyId: input.companyId,
+      feature: input.feature,
+      jobType: input.jobType || undefined,
+      provider: input.provider || "local",
+      modelName: input.modelName || undefined,
+      entityType: input.entityType || "SYSTEM",
+      entityId: input.entityId || input.companyId,
+      usageKind: input.usageKind || "ESTIMATED",
+      workloadUnits,
+      runtimeMs,
+      localComputeMs: boundNumber(input.localComputeMs),
+      inputTokens,
+      outputTokens,
+      externalRequests,
+      retryCount,
+      estimatedCostMicros,
+      actualCostMicros: input.actualCostMicros === undefined ? undefined : boundNumber(input.actualCostMicros),
+      valueSignal: input.valueSignal || "UNKNOWN",
+      metadata: (input.metadata || {}) as Prisma.InputJsonValue,
+    },
+  });
+}
+
+function dollarsFromMicros(micros: number) {
+  return Math.round((micros / 1_000_000) * 100) / 100;
+}
+
+function summarizeUsage(usages: Array<{
+  feature: string;
+  estimatedCostMicros: number;
+  actualCostMicros: number | null;
+  workloadUnits: number;
+  runtimeMs: number;
+  externalRequests: number;
+  retryCount: number;
+}>) {
+  const byFeature = new Map<string, {
+    feature: string;
+    estimatedCostMicros: number;
+    actualCostMicros: number;
+    workloadUnits: number;
+    runtimeMs: number;
+    externalRequests: number;
+    retryCount: number;
+    records: number;
+  }>();
+
+  for (const usage of usages) {
+    const existing = byFeature.get(usage.feature) || {
+      feature: usage.feature,
+      estimatedCostMicros: 0,
+      actualCostMicros: 0,
+      workloadUnits: 0,
+      runtimeMs: 0,
+      externalRequests: 0,
+      retryCount: 0,
+      records: 0,
+    };
+    existing.estimatedCostMicros += usage.estimatedCostMicros;
+    existing.actualCostMicros += usage.actualCostMicros ?? 0;
+    existing.workloadUnits += usage.workloadUnits;
+    existing.runtimeMs += usage.runtimeMs;
+    existing.externalRequests += usage.externalRequests;
+    existing.retryCount += usage.retryCount;
+    existing.records += 1;
+    byFeature.set(usage.feature, existing);
+  }
+
+  return Array.from(byFeature.values())
+    .map((item) => ({
+      ...item,
+      estimatedCost: dollarsFromMicros(item.estimatedCostMicros),
+      actualCost: dollarsFromMicros(item.actualCostMicros),
+    }))
+    .sort((a, b) => b.estimatedCostMicros - a.estimatedCostMicros);
+}
+
+function virtualPolicies(policies: Array<{
+  feature: string;
+  status: string;
+  dailyEstimatedCostMicros: number;
+  dailyWorkloadUnitsLimit: number;
+  retryLimit: number;
+  externalRequestLimit: number;
+  controlMode: string;
+}>) {
+  const policyMap = new Map(policies.map((policy) => [policy.feature, policy]));
+  for (const policy of DEFAULT_POLICIES) {
+    if (!policyMap.has(policy.feature)) {
+      policyMap.set(policy.feature, {
+        ...policy,
+        status: "VIRTUAL_DEFAULT",
+        controlMode: "MONITOR",
+      });
+    }
+  }
+  return Array.from(policyMap.values());
+}
+
+function recommendedBudgetEvents(params: {
+  usageByFeature: ReturnType<typeof summarizeUsage>;
+  policies: ReturnType<typeof virtualPolicies>;
+  activeJobs: Array<{ status: string; attemptCount: number; jobType: string; updatedAt: Date }>;
+  evaluationFailureCount: number;
+}) {
+  const events = [];
+  const policyMap = new Map(params.policies.map((policy) => [policy.feature, policy]));
+
+  for (const usage of params.usageByFeature) {
+    const policy = policyMap.get(usage.feature);
+    if (!policy) continue;
+    if (usage.estimatedCostMicros > policy.dailyEstimatedCostMicros) {
+      events.push({
+        feature: usage.feature,
+        eventType: "DAILY_ESTIMATED_COST_LIMIT",
+        severity: "WARN",
+        valueAssessment: usage.retryCount > policy.retryLimit ? "POSSIBLE_WASTE" : "HIGH_COST_HIGH_VALUE_REVIEW",
+        recommendation: "Review cost drivers, then cache/reuse, batch, or require review for repeated low-value work.",
+        evidence: { usage, policy },
+      });
+    }
+    if (usage.retryCount > policy.retryLimit) {
+      events.push({
+        feature: usage.feature,
+        eventType: "RETRY_LIMIT_PRESSURE",
+        severity: "WARN",
+        valueAssessment: "POSSIBLE_WASTE",
+        recommendation: "Inspect retry causes before allowing more autonomous attempts.",
+        evidence: { retryCount: usage.retryCount, retryLimit: policy.retryLimit },
+      });
+    }
+  }
+
+  const failedJobs = params.activeJobs.filter((job) => job.status === "FAILED");
+  const highRetryJobs = params.activeJobs.filter((job) => job.attemptCount >= 3);
+  if (failedJobs.length || highRetryJobs.length) {
+    events.push({
+      feature: "pipeline-queue",
+      eventType: "QUEUE_RETRY_OR_FAILURE_PRESSURE",
+      severity: failedJobs.length > 2 ? "CRITICAL" : "WARN",
+      valueAssessment: "POSSIBLE_WASTE",
+      recommendation: "Recover failed jobs only after reviewing repeated failure reasons; consider pause or review-required controls.",
+      evidence: {
+        failedJobs: failedJobs.length,
+        highRetryJobs: highRetryJobs.length,
+        jobTypes: Array.from(new Set([...failedJobs, ...highRetryJobs].map((job) => job.jobType))).slice(0, 6),
+      },
+    });
+  }
+
+  if (params.evaluationFailureCount > 0) {
+    events.push({
+      feature: "evaluation-bench",
+      eventType: "FAILED_EVAL_REPLAY",
+      severity: "INFO",
+      valueAssessment: "HIGH_COST_HIGH_VALUE_REVIEW",
+      recommendation: "Keep eval usage visible, but treat failed gates as valuable safety work before throttling.",
+      evidence: { evaluationFailureCount: params.evaluationFailureCount },
+    });
+  }
+
+  return events;
+}
+
+export async function getCompanyBudgetSnapshot(companyId: string) {
+  const since = new Date(Date.now() - DAY_MS);
+  const [usages, policies, openEvents, activeJobs, evaluationFailures] = await Promise.all([
+    prisma.aiWorkloadUsage.findMany({
+      where: { companyId, createdAt: { gte: since } },
+      orderBy: [{ createdAt: "desc" }],
+      take: 200,
+    }),
+    prisma.budgetPolicy.findMany({
+      where: { companyId },
+      orderBy: [{ updatedAt: "desc" }],
+    }),
+    prisma.budgetEvent.findMany({
+      where: { companyId, status: "OPEN" },
+      orderBy: [{ createdAt: "desc" }],
+      take: 20,
+    }),
+    prisma.pipelineJob.findMany({
+      where: { companyId, status: { in: ["ACTIVE", "RUNNING", "FAILED"] } },
+      orderBy: [{ updatedAt: "desc" }],
+      take: 100,
+    }),
+    prisma.outcomeEvent.count({
+      where: { companyId, outcomeType: "EVAL_GATE_FAILED", createdAt: { gte: since } },
+    }),
+  ]);
+
+  const usageByFeature = summarizeUsage(usages);
+  const totalEstimatedCostMicros = usageByFeature.reduce((sum, item) => sum + item.estimatedCostMicros, 0);
+  const totalWorkloadUnits = Math.round(usageByFeature.reduce((sum, item) => sum + item.workloadUnits, 0) * 10) / 10;
+  const policyList = virtualPolicies(policies);
+  const recommendations = recommendedBudgetEvents({
+    usageByFeature,
+    policies: policyList,
+    activeJobs,
+    evaluationFailureCount: evaluationFailures,
+  });
+  const pressure = recommendations.some((event) => event.severity === "CRITICAL")
+    ? "CRITICAL"
+    : recommendations.some((event) => event.severity === "WARN")
+      ? "WATCH"
+      : "NORMAL";
+
+  return {
+    windowHours: 24,
+    pressure,
+    totalEstimatedCostMicros,
+    totalEstimatedCost: dollarsFromMicros(totalEstimatedCostMicros),
+    totalWorkloadUnits,
+    usageCount: usages.length,
+    usageByFeature,
+    policies: policyList,
+    openEvents,
+    recommendations,
+  };
+}
+
+export async function applyBudgetControl(input: {
+  companyId: string;
+  feature: string;
+  control: "THROTTLE" | "BATCH" | "CACHE_REUSE" | "REVIEW_REQUIRED" | "PAUSE";
+  actorEmail?: string | null;
+}) {
+  const controls = {
+    appliedControl: input.control,
+    appliedAt: new Date().toISOString(),
+    actorEmail: input.actorEmail || null,
+  };
+
+  const policy = await prisma.budgetPolicy.upsert({
+    where: { companyId_feature: { companyId: input.companyId, feature: input.feature } },
+    create: {
+      companyId: input.companyId,
+      feature: input.feature,
+      controlMode: input.control,
+      controls,
+    },
+    update: {
+      controlMode: input.control,
+      controls,
+    },
+  });
+
+  const event = await prisma.budgetEvent.create({
+    data: {
+      companyId: input.companyId,
+      feature: input.feature,
+      eventType: "BUDGET_CONTROL_APPLIED",
+      severity: "INFO",
+      status: "RESOLVED",
+      recommendation: `Applied ${input.control} control to ${input.feature}.`,
+      valueAssessment: input.control === "PAUSE" ? "POSSIBLE_WASTE" : "HIGH_COST_HIGH_VALUE_REVIEW",
+      evidence: { policyId: policy.id, controls },
+      appliedControl: input.control,
+      actorEmail: input.actorEmail || undefined,
+      resolvedAt: new Date(),
+    },
+  });
+
+  return { policy, event };
+}

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { getCompanyBudgetSnapshot } from "@/lib/budget-governor";
 import { prisma } from "@/lib/db";
 import { computeCompanyScoreHealth } from "@/lib/score-health";
 
@@ -15,7 +16,7 @@ async function readJsonFile<T>(filePath: string): Promise<T | null> {
 }
 
 export async function getCompanyObservabilitySnapshot(companyId: string) {
-  const [guardianHeartbeat, scoreHealth, activeJobs, workerReports, recentEvents] = await Promise.all([
+  const [guardianHeartbeat, scoreHealth, activeJobs, workerReports, recentEvents, budget] = await Promise.all([
     readJsonFile<Record<string, unknown>>(GUARDIAN_HEARTBEAT_PATH),
     computeCompanyScoreHealth(companyId, prisma),
     prisma.pipelineJob.findMany({
@@ -32,6 +33,7 @@ export async function getCompanyObservabilitySnapshot(companyId: string) {
       orderBy: [{ createdAt: "desc" }],
       take: 10,
     }),
+    getCompanyBudgetSnapshot(companyId),
   ]);
 
   const failedJobs = activeJobs.filter((job) => job.status === "FAILED").length;
@@ -52,12 +54,14 @@ export async function getCompanyObservabilitySnapshot(companyId: string) {
       escalateScoreRepair: Boolean(criticalAlert || scoreHealth?.overallBand === "SUSPICIOUS"),
       recoverFailedJobs: failedJobs > 0,
       reviewEvaluationFailures: evaluationFailures.length > 0,
+      reviewBudgetPressure: budget.pressure !== "NORMAL" || budget.openEvents.length > 0,
       syncQueue: true,
     },
     evaluation: {
       recentFailures: evaluationFailures,
       failedGateCount: evaluationFailures.length,
     },
+    budget,
     workerReports,
     recentEvents,
   };


### PR DESCRIPTION
## Summary\n\nImplements the first #173 budget-governor slice:\n- adds AiWorkloadUsage, BudgetPolicy, and BudgetEvent persistence\n- records workload usage from pipeline queue jobs, evaluation replays, content generation, and observability actions\n- adds Observability budget pressure, workload attribution, recommendations, and bounded controls for queue throttle, evaluation batching, and cache/reuse\n- updates SSOT, system design, rulebook, local pipeline, README, and handover docs\n\nCloses #173 when merged.\n\n## Validation\n\n- npx prisma generate\n- npm run audit:docs\n- npm run audit:semantic\n- npm run lint\n- npx tsc --noEmit\n- local unauthenticated API smoke confirmed login gating for observability/evaluations