### PR TITLE
Add voice-of-customer signal fusion

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -42,6 +42,8 @@ Read first:
 - content generation persists outputs as `CreativeDraft` records and records generation/audit events without automated posting
 - AI workload governance now persists `AiWorkloadUsage`, `BudgetPolicy`, and `BudgetEvent` records so queue, evaluation, content-generation, and observability work can be attributed by company and feature
 - budget controls are operator-applied and reviewable: queue throttling, evaluation batching, and cache/reuse policy changes do not silently suppress critical evidence work
+- the webapp now exposes `Customer Voice` for recording reviews/support/survey/sales/social/interview signals and fusing them into evidence-backed themes and action briefs
+- customer voice records persist as `VocSignal`, `VocTheme`, and `VocActionBrief` entries and are available to Search & Answers
 - the webapp now exposes `Athlete App` beside the coach/operator surfaces so athletes can see coach-assigned checklist work, record daily activity, wellness/body metrics, and mark assigned work complete
 - the webapp also exposes `Athletes` as the coach-facing records view for team daily logs, completion evidence, readiness, load, sleep, soreness, and pain flags
 - athlete records persist as `AthleteActivityLog` entries keyed by company, athlete email, day, and optional assigned task
@@ -126,5 +128,6 @@ The work is not done until:
 - Evaluation bench replay is advisory first: synthetic fixtures and rubric gates compare baseline vs candidate behavior without production writes unless failed gates are explicitly published to Observability.
 - Content generation is draft-only: it can create and persist channel-specific copy, but it must not post externally or generate images in the first release.
 - Budget governor is observability-first: usage/cost values are estimates unless explicitly marked actual, and controls are recorded as events/policies rather than hidden scheduling overrides.
+- Customer voice fusion is evidence-first: themes and briefs preserve source excerpts, segment metadata, confidence, review state, and root-cause hypotheses.
 - Athlete app is athlete-facing: it records daily activity, wellness/body metrics, and completion evidence but does not replace the coach/operator planning surfaces.
 - Athlete records is coach-facing: it can summarize team submissions, but planning and assignment still stay in the coach/operator checklist surfaces.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ New operator surfaces:
 - enrichment-waterfall policies now affect runtime provider selection for URL intelligence instead of living as config-only records
 - `/:companyId/evaluations` provides an advisory evaluation bench for recommendation, grounded-answer, search, KPI, workflow, competitor, and data-readiness behavior before intelligence changes are promoted
 - `/:companyId/content-generation` generates and saves evidence-aware email subjects, platform ad copy, social posts, and landing-page sections from product and competitor context
+- `/:companyId/voc` records customer-language signals and fuses them into evidence-backed themes, root-cause hypotheses, and action briefs
 - `/:companyId/athlete` provides an athlete-facing daily app for coach-assigned work, activity recording, wellness/body metrics, readiness notes, and completion records
 - `/:companyId/athletes` provides a coach-facing athlete records view for daily team logs, completion evidence, load, sleep, soreness, readiness, and pain flags
 

--- a/docs/LOCAL_AI_PIPELINE.md
+++ b/docs/LOCAL_AI_PIPELINE.md
@@ -404,6 +404,18 @@ The first AI workload budget-governor slice is an observability-first control lo
 - evaluation and content-generation APIs record usage when operators run those surfaces
 - Observability shows budget pressure, usage by feature, recommendations, and bounded controls without silently overriding human-guided scheduling or critical safety/evidence work
 
+## Voice of customer
+
+The first VoC signal-fusion slice makes customer language durable and searchable:
+
+- `VocSignal` stores reviews, support notes, survey responses, sales objections, social/listening snippets, cancellation reasons, interview notes, and manual notes with provenance metadata
+- `voc-signal-fusion.ts` normalizes channel/sentiment/urgency and groups signals into transparent deterministic themes
+- `VocTheme` stores affected segments, supporting excerpts, sentiment mix, confidence, recurrence, freshness, and review state
+- `VocActionBrief` stores root-cause hypotheses and recommended next work backed by the theme evidence excerpts
+- `/api/voc` records signals and recomputes themes/briefs behind company membership checks
+- `/:companyId/voc` gives operators a customer-voice surface beside Knowmore, Goals, Checklist, and Search & Answers
+- search and grounded answers include customer themes and briefs as retrievable company context
+
 ## Delivery modes
 
 There is one supported hosted execution mode:

--- a/docs/RULEBOOK.md
+++ b/docs/RULEBOOK.md
@@ -222,6 +222,14 @@ Budget governor rules:
 - budget events must distinguish high-cost high-value work from likely waste such as retry storms, repeated failed jobs, or low-value repeated generation
 - Observability is the first budget-governor surface; budget controls must stay bounded to throttle, batch, cache/reuse, review-required, or pause policies until the system has stronger outcome evidence
 
+Voice-of-customer rules:
+
+- customer-language signals must preserve channel, provenance, segment/lifecycle metadata when available, sentiment, urgency, and source excerpt
+- themes and action briefs must preserve supporting excerpts and signal IDs; customer evidence must not become an unsourced summary
+- sentiment must not be the only prioritization signal; recurrence, urgency, freshness, segment impact, and confidence must also contribute
+- contradictory or mixed signals must lower confidence or create an explicit review state rather than silently averaging away disagreement
+- the first release must not add public social-listening automation, contact-center agent automation, survey-builder parity, or medical/legal-style customer claims
+
 Athlete app rules:
 
 - athlete-facing recording must be separate from coach/operator planning surfaces while reusing the same company membership boundary

--- a/docs/SSOT.md
+++ b/docs/SSOT.md
@@ -104,6 +104,8 @@ The current intelligence-operations contract also includes:
 - one content-generation surface that turns existing company, product, goal, topic, and competitor context into saved `CreativeDraft` records for email subjects, ads, social posts, and landing-page copy
 - content generation is draft-only in the current contract: no automated posting, no image generation, and no multi-language generation
 - one AI workload budget-governor layer that persists `AiWorkloadUsage`, `BudgetPolicy`, and `BudgetEvent` records for company/feature attribution, estimated cost, workload units, retry pressure, reviewable budget events, and explicit operator-applied controls
+- one voice-of-customer signal-fusion layer that persists `VocSignal`, `VocTheme`, and `VocActionBrief` records for customer-language evidence, themes, root-cause hypotheses, confidence/review state, and source-backed action briefs
+- customer voice themes and action briefs participate in Search & Answers as first-class retrievable evidence/work objects
 - one athlete-facing daily app beside the coach/operator app, backed by `AthleteActivityLog`, where athletes can see assigned checklist work, record activity, readiness, intensity, sleep, soreness, stress, mood, hydration, body weight, pain/nutrition notes, and completion evidence
 - one coach-facing athlete records view where admins can review team daily submissions, completion evidence, load, readiness, sleep, soreness, and pain flags
 - completing coach-assigned work from the athlete app records an athlete outcome and archives the assigned checklist item as completed

--- a/docs/SYSTEM_DESIGN_LLD.md
+++ b/docs/SYSTEM_DESIGN_LLD.md
@@ -122,6 +122,7 @@ The repetitive-job system now has a first-class queue model:
 - `grounded-answers.ts` builds bounded evidence-backed answers on top of the internal search layer, including explicit intent/confidence/evidence-group fields
 - `observability.ts` aggregates heartbeat, queue, score-health, worker reports, and recent outcomes for mission-control surfaces, and drives bounded repair recommendations
 - `budget-governor.ts` owns workload usage attribution, virtual/default budget policies, budget-pressure summaries, recommended budget events, and explicit control application for queue/evaluation/content/observability work
+- `voc-signal-fusion.ts` owns customer-signal normalization, channel/sentiment constraints, deterministic theme grouping, confidence scoring, and action-brief payload construction
 - `workflow-blueprints.ts` owns the persisted bounded workflow-builder contract and default blueprint registry; active blueprints are synchronized into `PipelineJob` records and executed by the shared queue worker
 - `enrichment-waterfall.ts` owns the persisted provider-ordering and fallback policy contract for enrichment governance, and `url-enrichment.ts` consumes that policy at runtime for product/competitor research
 
@@ -167,3 +168,13 @@ The repetitive-job system now has a first-class queue model:
 - queue worker completion/failure, evaluation POSTs, content-generation POSTs, and observability actions all record workload usage in the first slice
 - Observability renders budget pressure, workload attribution, recommended budget events, and bounded controls for throttling queue work, batching evaluations, and cache/reuse policy
 - budget controls must not silently erase human-guided queue ordering or suppress critical evidence/safety work
+
+## 14. Voice Of Customer Architecture
+
+- `VocSignal` stores source customer language with channel, provenance, segment, lifecycle stage, sentiment, urgency, account value, and excerpt metadata
+- `VocTheme` stores fused themes with supporting signal IDs, source excerpts, affected segments, sentiment mix, trend direction, confidence, recurrence, and review state
+- `VocActionBrief` stores source-backed next-work recommendations with root cause, affected segment, priority, status, and evidence excerpts
+- `/api/voc` runs behind normal company membership checks and supports listing signals/themes/briefs plus recording new customer-language evidence
+- `/:companyId/voc` is the operator surface for recording customer signals and reviewing fused themes/action briefs
+- `internal-search.ts` and grounded answers include `VOC_THEME` and `VOC_ACTION_BRIEF` records so customer evidence can inform answers and execution queries
+- the first release uses deterministic transparent grouping and must not claim social-listening automation, contact-center automation, or sentiment-only prioritization

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,9 @@ model Company {
   aiWorkloadUsages     AiWorkloadUsage[]
   budgetPolicies       BudgetPolicy[]
   budgetEvents         BudgetEvent[]
+  vocSignals           VocSignal[]
+  vocThemes            VocTheme[]
+  vocActionBriefs      VocActionBrief[]
   
   // Profile Validation Fields
   website             String?
@@ -692,6 +695,74 @@ model BudgetEvent {
 
   @@index([companyId, status, severity, createdAt])
   @@index([companyId, feature, createdAt])
+}
+
+model VocSignal {
+  id              String   @id @default(uuid()) @map("_id")
+  companyId       String
+  channel         String   @default("NOTE")
+  sourceLabel     String?
+  customerSegment String?
+  lifecycleStage  String?
+  sentiment       String   @default("NEUTRAL")
+  urgency         Int      @default(3)
+  accountValue    Float?
+  title           String
+  excerpt         String
+  provenanceUrl   String?
+  occurredAt      DateTime @default(now())
+  metadata        Json?    @default("{}")
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @default(now()) @updatedAt
+  company         Company  @relation(fields: [companyId], references: [id], onDelete: Cascade)
+
+  @@index([companyId, channel, occurredAt])
+  @@index([companyId, sentiment, urgency])
+}
+
+model VocTheme {
+  id                  String   @id @default(uuid()) @map("_id")
+  companyId           String
+  status              String   @default("ACTIVE")
+  title               String
+  summary             String
+  rootCauseHypothesis String
+  affectedSegments    String[] @default([])
+  signalIds           String[] @default([])
+  supportingExcerpts  Json?    @default("[]")
+  sentimentMix        Json?    @default("{}")
+  trendDirection      String   @default("STABLE")
+  confidence          Int      @default(50)
+  impactScore         Int      @default(5)
+  recurrenceScore     Int      @default(1)
+  freshnessScore      Int      @default(5)
+  reviewState         String   @default("READY")
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @default(now()) @updatedAt
+  company             Company  @relation(fields: [companyId], references: [id], onDelete: Cascade)
+
+  @@index([companyId, status, confidence])
+  @@index([companyId, reviewState, updatedAt])
+}
+
+model VocActionBrief {
+  id               String   @id @default(uuid()) @map("_id")
+  companyId        String
+  themeId          String?
+  status           String   @default("DRAFT")
+  title            String
+  rootCause        String
+  affectedSegment  String?
+  recommendedWork  String
+  nextStepType     String   @default("CHECKLIST")
+  priorityScore    Float    @default(0)
+  evidence         Json?    @default("[]")
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @default(now()) @updatedAt
+  company          Company  @relation(fields: [companyId], references: [id], onDelete: Cascade)
+
+  @@index([companyId, status, priorityScore])
+  @@index([companyId, themeId, createdAt])
 }
 
 model WorkflowBlueprint {

--- a/src/app/[companyId]/search/page.tsx
+++ b/src/app/[companyId]/search/page.tsx
@@ -26,6 +26,10 @@ function toneLabel(entityType: SearchResultRecord["entityType"]) {
       return "Worker Queue";
     case "WORKFLOW_BLUEPRINT":
       return "Workflow";
+    case "VOC_THEME":
+      return "Customer Theme";
+    case "VOC_ACTION_BRIEF":
+      return "Customer Brief";
   }
 }
 
@@ -43,6 +47,8 @@ export default function SearchPage() {
     TASK: 0,
     PIPELINE_JOB: 0,
     WORKFLOW_BLUEPRINT: 0,
+    VOC_THEME: 0,
+    VOC_ACTION_BRIEF: 0,
   });
   const [answer, setAnswer] = useState<GroundedAnswer | null>(null);
   const [selectedTypes, setSelectedTypes] = useState<SearchEntityType[]>([
@@ -53,6 +59,8 @@ export default function SearchPage() {
     "TASK",
     "PIPELINE_JOB",
     "WORKFLOW_BLUEPRINT",
+    "VOC_THEME",
+    "VOC_ACTION_BRIEF",
   ]);
 
   const entityOptions: Array<{ value: SearchEntityType; label: string }> = [
@@ -63,6 +71,8 @@ export default function SearchPage() {
     { value: "TASK", label: "Tasks" },
     { value: "PIPELINE_JOB", label: "Queue" },
     { value: "WORKFLOW_BLUEPRINT", label: "Workflows" },
+    { value: "VOC_THEME", label: "Customer Themes" },
+    { value: "VOC_ACTION_BRIEF", label: "Customer Briefs" },
   ];
 
   const runSearch = useCallback(async () => {
@@ -88,6 +98,8 @@ export default function SearchPage() {
         TASK: 0,
         PIPELINE_JOB: 0,
         WORKFLOW_BLUEPRINT: 0,
+        VOC_THEME: 0,
+        VOC_ACTION_BRIEF: 0,
       });
       setAnswer(answerData);
     } finally {

--- a/src/app/[companyId]/voc/page.tsx
+++ b/src/app/[companyId]/voc/page.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import {
+  Badge,
+  Button,
+  Group,
+  Loader,
+  NumberInput,
+  SegmentedControl,
+  SimpleGrid,
+  Stack,
+  Table,
+  TextInput,
+  Textarea,
+} from "@mantine/core";
+import {
+  IconAlertTriangle as AlertTriangle,
+  IconMessageCircle as MessageCircle,
+  IconReportAnalytics as ReportAnalytics,
+  IconSparkles as Sparkles,
+  IconTargetArrow as TargetArrow,
+} from "@tabler/icons-react";
+import { MetricCard, Notice, PageHeader, PageShell } from "@/components/ui/app-shell";
+import { BodyText, MetaText } from "@/components/ui/typography";
+import { UnifiedCard, UnifiedCardBody, UnifiedCardHeader } from "@/components/ui/unified-card";
+import { VOC_CHANNELS, type VocChannel, type VocSentiment } from "@/lib/voc-signal-fusion";
+
+type VocPayload = {
+  signals: Array<{
+    id: string;
+    channel: string;
+    sentiment: string;
+    urgency: number;
+    title: string;
+    excerpt: string;
+    customerSegment?: string | null;
+    sourceLabel?: string | null;
+    occurredAt: string;
+  }>;
+  themes: Array<{
+    id: string;
+    title: string;
+    summary: string;
+    rootCauseHypothesis: string;
+    confidence: number;
+    reviewState: string;
+    affectedSegments: string[];
+    recurrenceScore: number;
+  }>;
+  briefs: Array<{
+    id: string;
+    title: string;
+    rootCause: string;
+    affectedSegment?: string | null;
+    recommendedWork: string;
+    priorityScore: number;
+    status: string;
+  }>;
+  summary: {
+    totalSignals: number;
+    negativeSignals: number;
+    urgentSignals: number;
+    totalThemes: number;
+    reviewThemes: number;
+    actionBriefs: number;
+    openBriefs: number;
+    averageThemeConfidence: number;
+  };
+  error?: string;
+};
+
+const SENTIMENT_OPTIONS: Array<{ value: VocSentiment; label: string }> = [
+  { value: "NEGATIVE", label: "Negative" },
+  { value: "MIXED", label: "Mixed" },
+  { value: "NEUTRAL", label: "Neutral" },
+  { value: "POSITIVE", label: "Positive" },
+];
+
+export default function VocPage() {
+  const params = useParams();
+  const companyId = params.companyId as string;
+  const [data, setData] = useState<VocPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [channel, setChannel] = useState<VocChannel>("SUPPORT");
+  const [sentiment, setSentiment] = useState<VocSentiment>("NEGATIVE");
+  const [urgency, setUrgency] = useState<number | "">(4);
+  const [title, setTitle] = useState("");
+  const [excerpt, setExcerpt] = useState("");
+  const [customerSegment, setCustomerSegment] = useState("");
+  const [sourceLabel, setSourceLabel] = useState("");
+  const [lifecycleStage, setLifecycleStage] = useState("");
+  const [provenanceUrl, setProvenanceUrl] = useState("");
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/voc?companyId=${companyId}`);
+      setData(await response.json());
+    } finally {
+      setLoading(false);
+    }
+  }, [companyId]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void loadData();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [loadData]);
+
+  const resetForm = () => {
+    setTitle("");
+    setExcerpt("");
+    setCustomerSegment("");
+    setSourceLabel("");
+    setLifecycleStage("");
+    setProvenanceUrl("");
+    setUrgency(4);
+    setSentiment("NEGATIVE");
+    setChannel("SUPPORT");
+  };
+
+  const submitSignal = useCallback(async () => {
+    if (!excerpt.trim()) return;
+    setSaving(true);
+    try {
+      const response = await fetch("/api/voc", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          companyId,
+          channel,
+          sentiment,
+          urgency,
+          title,
+          excerpt,
+          customerSegment,
+          sourceLabel,
+          lifecycleStage,
+          provenanceUrl,
+        }),
+      });
+      setData(await response.json());
+      resetForm();
+    } finally {
+      setSaving(false);
+    }
+  }, [channel, companyId, customerSegment, excerpt, lifecycleStage, provenanceUrl, sentiment, sourceLabel, title, urgency]);
+
+  if (loading) {
+    return (
+      <PageShell width="full">
+        <Stack align="center" py="xl">
+          <Loader />
+        </Stack>
+      </PageShell>
+    );
+  }
+
+  const summary = data?.summary || {
+    totalSignals: 0,
+    negativeSignals: 0,
+    urgentSignals: 0,
+    totalThemes: 0,
+    reviewThemes: 0,
+    actionBriefs: 0,
+    openBriefs: 0,
+    averageThemeConfidence: 0,
+  };
+
+  return (
+    <PageShell width="full">
+      <PageHeader
+        title="Customer Voice"
+        description="Evidence-backed customer signal fusion for themes, root-cause hypotheses, and action briefs."
+      />
+
+      {data?.error ? <Notice title="Customer voice unavailable">{data.error}</Notice> : null}
+
+      <SimpleGrid cols={{ base: 1, md: 2, xl: 4 }} spacing="md">
+        <MetricCard icon={MessageCircle} color="knowmore" label="Signals" value={summary.totalSignals} detail={`${summary.negativeSignals} negative`} />
+        <MetricCard icon={Sparkles} color="strategy" label="Themes" value={summary.totalThemes} detail={`Confidence ${summary.averageThemeConfidence}%`} />
+        <MetricCard icon={TargetArrow} color="checklist" label="Action Briefs" value={summary.openBriefs} detail={`${summary.actionBriefs} total`} />
+        <MetricCard icon={AlertTriangle} color="review" label="Urgent" value={summary.urgentSignals} detail={`${summary.reviewThemes} themes need review`} />
+      </SimpleGrid>
+
+      <SimpleGrid cols={{ base: 1, xl: 2 }} spacing="lg">
+        <UnifiedCard tone="knowmore">
+          <UnifiedCardHeader title="Record Customer Signal" supporting={<Badge variant="light" color="knowmore">VoC</Badge>} />
+          <UnifiedCardBody>
+            <SegmentedControl
+              value={channel}
+              data={VOC_CHANNELS.map((item) => ({ value: item.value, label: item.label }))}
+              onChange={(value) => setChannel(value as VocChannel)}
+            />
+            <SegmentedControl
+              value={sentiment}
+              data={SENTIMENT_OPTIONS}
+              onChange={(value) => setSentiment(value as VocSentiment)}
+            />
+            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
+              <TextInput label="Title" placeholder="Pricing concern, support delay, missing export..." value={title} onChange={(event) => setTitle(event.currentTarget.value)} />
+              <NumberInput label="Urgency" min={1} max={5} value={urgency} onChange={(value) => setUrgency(typeof value === "number" ? value : "")} />
+            </SimpleGrid>
+            <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+              <TextInput label="Segment" placeholder="Enterprise, trial users..." value={customerSegment} onChange={(event) => setCustomerSegment(event.currentTarget.value)} />
+              <TextInput label="Lifecycle" placeholder="Trial, renewal, churn..." value={lifecycleStage} onChange={(event) => setLifecycleStage(event.currentTarget.value)} />
+              <TextInput label="Source" placeholder="G2, support, sales call..." value={sourceLabel} onChange={(event) => setSourceLabel(event.currentTarget.value)} />
+            </SimpleGrid>
+            <Textarea
+              label="Customer language"
+              placeholder="Paste the review, support note, survey answer, sales objection, or interview excerpt..."
+              minRows={5}
+              autosize
+              value={excerpt}
+              onChange={(event) => setExcerpt(event.currentTarget.value)}
+            />
+            <TextInput label="Provenance URL" placeholder="Optional source URL" value={provenanceUrl} onChange={(event) => setProvenanceUrl(event.currentTarget.value)} />
+            <Group gap="sm">
+              <Button leftSection={<MessageCircle size={16} />} loading={saving} onClick={() => void submitSignal()}>
+                Fuse Signal
+              </Button>
+              <Button variant="light" color="review" onClick={resetForm}>
+                Clear
+              </Button>
+            </Group>
+          </UnifiedCardBody>
+        </UnifiedCard>
+
+        <UnifiedCard tone="strategy">
+          <UnifiedCardHeader title="Themes" supporting={<Badge variant="light" color="strategy">{data?.themes.length || 0}</Badge>} />
+          <UnifiedCardBody>
+            <Stack gap="md">
+              {(data?.themes || []).length === 0 ? (
+                <Notice title="No themes yet">Add customer-language evidence to create the first theme and action brief.</Notice>
+              ) : null}
+              {(data?.themes || []).map((theme) => (
+                <Stack key={theme.id} gap="xs">
+                  <Group gap="xs">
+                    <Badge variant="light" color={theme.reviewState === "REVIEW" ? "review" : "strategy"}>{theme.reviewState}</Badge>
+                    <Badge variant="outline" color="gray">{theme.confidence}% confidence</Badge>
+                    <Badge variant="outline" color="gray">{theme.recurrenceScore} signals</Badge>
+                  </Group>
+                  <BodyText>{theme.title}</BodyText>
+                  <MetaText>{theme.summary}</MetaText>
+                  <MetaText>Root cause: {theme.rootCauseHypothesis}</MetaText>
+                </Stack>
+              ))}
+            </Stack>
+          </UnifiedCardBody>
+        </UnifiedCard>
+      </SimpleGrid>
+
+      <UnifiedCard tone="checklist">
+        <UnifiedCardHeader title="Action Briefs" supporting={<Badge variant="light" color="checklist">{data?.briefs.length || 0}</Badge>} />
+        <UnifiedCardBody>
+          <Table highlightOnHover>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Brief</Table.Th>
+                <Table.Th>Segment</Table.Th>
+                <Table.Th>Priority</Table.Th>
+                <Table.Th>Status</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {(data?.briefs || []).map((brief) => (
+                <Table.Tr key={brief.id}>
+                  <Table.Td>
+                    <Stack gap={2}>
+                      <BodyText>{brief.title}</BodyText>
+                      <MetaText>{brief.recommendedWork}</MetaText>
+                      <MetaText>Root cause: {brief.rootCause}</MetaText>
+                    </Stack>
+                  </Table.Td>
+                  <Table.Td>{brief.affectedSegment || "—"}</Table.Td>
+                  <Table.Td>{Math.round(brief.priorityScore)}</Table.Td>
+                  <Table.Td>
+                    <Badge variant="light" color="gray">{brief.status}</Badge>
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </UnifiedCardBody>
+      </UnifiedCard>
+
+      <UnifiedCard tone="review">
+        <UnifiedCardHeader title="Recent Signals" supporting={<Badge variant="light" color="review">{data?.signals.length || 0}</Badge>} />
+        <UnifiedCardBody>
+          <Stack gap="sm">
+            {(data?.signals || []).map((signal) => (
+              <Group key={signal.id} justify="space-between" align="flex-start">
+                <Stack gap={2} style={{ flex: 1 }}>
+                  <Group gap="xs">
+                    <Badge variant="outline" color="gray">{signal.channel}</Badge>
+                    <Badge variant="light" color={signal.sentiment === "NEGATIVE" ? "review" : "gray"}>{signal.sentiment}</Badge>
+                    <Badge variant="outline" color="gray">Urgency {signal.urgency}</Badge>
+                  </Group>
+                  <BodyText>{signal.title}</BodyText>
+                  <MetaText lineClamp={2}>{signal.excerpt}</MetaText>
+                </Stack>
+                <ReportAnalytics size={18} />
+              </Group>
+            ))}
+          </Stack>
+        </UnifiedCardBody>
+      </UnifiedCard>
+    </PageShell>
+  );
+}

--- a/src/app/api/companies/[companyId]/dashboard/route.ts
+++ b/src/app/api/companies/[companyId]/dashboard/route.ts
@@ -90,6 +90,12 @@ export async function GET(
             companyId: cid,
           },
         }),
+        prisma.vocTheme.count({
+          where: {
+            companyId: cid,
+            status: "ACTIVE",
+          },
+        }),
       ]).then(([
         sourceCount,
         fileCount,
@@ -102,6 +108,7 @@ export async function GET(
         pipelineJobCount,
         creativeDraftCount,
         athleteActivityLogCount,
+        vocThemeCount,
       ]) => ({
         sources: sourceCount + fileCount,
         files: fileCount,
@@ -114,6 +121,7 @@ export async function GET(
         pipelineJobs: pipelineJobCount,
         creativeDrafts: creativeDraftCount,
         athleteActivityLogs: athleteActivityLogCount,
+        vocThemes: vocThemeCount,
       })),
     ]);
 
@@ -144,6 +152,7 @@ export async function GET(
       pipelineJobs: liveCounts.pipelineJobs,
       creativeDrafts: liveCounts.creativeDrafts,
       athleteActivityLogs: liveCounts.athleteActivityLogs,
+      vocThemes: liveCounts.vocThemes,
     };
 
     return NextResponse.json({

--- a/src/app/api/voc/route.ts
+++ b/src/app/api/voc/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest, NextResponse } from "next/server";
+import { recordInteractionEventFromRequest, recordOutcomeEvent } from "@/lib/audit-ledger";
+import { prisma } from "@/lib/db";
+import { verifyMembership } from "@/lib/permissions";
+import { buildVocThemeCandidates, normalizeVocSignalInput, summarizeVoc } from "@/lib/voc-signal-fusion";
+
+export const dynamic = "force-dynamic";
+
+async function recomputeVoc(companyId: string) {
+  const signals = await prisma.vocSignal.findMany({
+    where: { companyId },
+    orderBy: [{ occurredAt: "desc" }, { createdAt: "desc" }],
+    take: 200,
+  });
+  const candidates = buildVocThemeCandidates(signals);
+
+  await prisma.$transaction([
+    prisma.vocTheme.deleteMany({ where: { companyId } }),
+    prisma.vocActionBrief.deleteMany({ where: { companyId } }),
+  ]);
+
+  for (const candidate of candidates) {
+    const theme = await prisma.vocTheme.create({
+      data: {
+        companyId,
+        title: candidate.title,
+        summary: candidate.summary,
+        rootCauseHypothesis: candidate.rootCauseHypothesis,
+        affectedSegments: candidate.affectedSegments,
+        signalIds: candidate.signalIds,
+        supportingExcerpts: candidate.supportingExcerpts,
+        sentimentMix: candidate.sentimentMix,
+        trendDirection: candidate.trendDirection,
+        confidence: candidate.confidence,
+        impactScore: candidate.impactScore,
+        recurrenceScore: candidate.recurrenceScore,
+        freshnessScore: candidate.freshnessScore,
+        reviewState: candidate.reviewState,
+      },
+    });
+
+    await prisma.vocActionBrief.create({
+      data: {
+        companyId,
+        themeId: theme.id,
+        title: candidate.actionBrief.title,
+        rootCause: candidate.actionBrief.rootCause,
+        affectedSegment: candidate.actionBrief.affectedSegment,
+        recommendedWork: candidate.actionBrief.recommendedWork,
+        nextStepType: candidate.actionBrief.nextStepType,
+        priorityScore: candidate.actionBrief.priorityScore,
+        evidence: candidate.actionBrief.evidence,
+      },
+    });
+  }
+
+  const [themes, briefs] = await Promise.all([
+    prisma.vocTheme.findMany({ where: { companyId }, orderBy: [{ confidence: "desc" }] }),
+    prisma.vocActionBrief.findMany({ where: { companyId }, orderBy: [{ priorityScore: "desc" }] }),
+  ]);
+
+  return { signals, themes, briefs, summary: summarizeVoc(signals, themes, briefs) };
+}
+
+export async function GET(request: NextRequest) {
+  const companyId = request.nextUrl.searchParams.get("companyId");
+  if (!companyId) {
+    return NextResponse.json({ error: "companyId required" }, { status: 400 });
+  }
+
+  const auth = await verifyMembership(request, companyId);
+  if (auth.error) return auth.error;
+
+  const [signals, themes, briefs] = await Promise.all([
+    prisma.vocSignal.findMany({
+      where: { companyId },
+      orderBy: [{ occurredAt: "desc" }, { createdAt: "desc" }],
+      take: 80,
+    }),
+    prisma.vocTheme.findMany({
+      where: { companyId },
+      orderBy: [{ confidence: "desc" }, { updatedAt: "desc" }],
+      take: 40,
+    }),
+    prisma.vocActionBrief.findMany({
+      where: { companyId },
+      orderBy: [{ priorityScore: "desc" }, { updatedAt: "desc" }],
+      take: 40,
+    }),
+  ]);
+
+  return NextResponse.json({
+    signals,
+    themes,
+    briefs,
+    summary: summarizeVoc(signals, themes, briefs),
+  });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const data = await request.json();
+    const companyId = String(data.companyId || "");
+    if (!companyId) {
+      return NextResponse.json({ error: "companyId required" }, { status: 400 });
+    }
+
+    const auth = await verifyMembership(request, companyId);
+    if (auth.error) return auth.error;
+
+    const signalInput = normalizeVocSignalInput(data);
+    if (!signalInput.excerpt) {
+      return NextResponse.json({ error: "excerpt required" }, { status: 400 });
+    }
+
+    const signal = await prisma.vocSignal.create({
+      data: {
+        companyId,
+        ...signalInput,
+      },
+    });
+    const recomputed = await recomputeVoc(companyId);
+
+    await recordInteractionEventFromRequest(request, {
+      companyId,
+      surface: "voice-of-customer",
+      interactionType: "VOC_SIGNAL_RECORDED",
+      entityType: "VOC_SIGNAL",
+      entityId: signal.id,
+      afterState: signal,
+      teachingWeight: 60,
+    });
+
+    await recordOutcomeEvent({
+      companyId,
+      actorType: "HUMAN",
+      actorEmail: auth.session.email,
+      entityType: "VOC_SIGNAL",
+      entityId: signal.id,
+      outcomeType: "VOC_SIGNAL_FUSED",
+      outcomeValue: signal.sentiment,
+      annotation: signal.title,
+      payload: {
+        channel: signal.channel,
+        urgency: signal.urgency,
+        themeCount: recomputed.themes.length,
+        briefCount: recomputed.briefs.length,
+      },
+      teachingWeight: 60,
+    });
+
+    return NextResponse.json({
+      signal,
+      ...recomputed,
+    });
+  } catch (error) {
+    console.error("[API:VoC] failure:", error);
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}

--- a/src/app/client-nav.tsx
+++ b/src/app/client-nav.tsx
@@ -19,7 +19,7 @@ import {
   Badge,
   Button
 } from "@mantine/core";
-import { IconChevronRight as ChevronRight, IconSun as Sun, IconMoon as Moon, IconLogout as LogOut, IconUser as UserIcon, IconSettings as SettingsIcon, IconLayoutDashboard as LayoutDashboard, IconDatabase as Database, IconListCheck as ListCheck, IconTarget as Target, IconSparkles as Sparkles, IconChevronDown as ChevronDown, IconHelmet as HardHat, IconLayersIntersect as Layers, IconHistory as History, IconFlask as Flask, IconPencil as Pencil, IconRun as Run, IconUsers as Users } from "@tabler/icons-react";
+import { IconChevronRight as ChevronRight, IconSun as Sun, IconMoon as Moon, IconLogout as LogOut, IconUser as UserIcon, IconSettings as SettingsIcon, IconLayoutDashboard as LayoutDashboard, IconDatabase as Database, IconListCheck as ListCheck, IconTarget as Target, IconSparkles as Sparkles, IconChevronDown as ChevronDown, IconHelmet as HardHat, IconLayersIntersect as Layers, IconHistory as History, IconFlask as Flask, IconPencil as Pencil, IconRun as Run, IconUsers as Users, IconMessageCircle as MessageCircle } from "@tabler/icons-react";
 import { Logo } from "@/components/ui/logo";
 import { useState, useEffect } from "react";
 import { usePathname, useRouter, useParams } from "next/navigation";
@@ -111,6 +111,14 @@ const pipelineItems = [
     tone: "knowmore",
   },
   {
+    key: "voc",
+    href: (companyId: string) => `/${companyId}/voc`,
+    label: "Customer Voice",
+    icon: MessageCircle,
+    color: "strategy",
+    tone: "strategy",
+  },
+  {
     key: "athlete",
     href: (companyId: string) => `/${companyId}/athlete`,
     label: "Athlete App",
@@ -189,6 +197,7 @@ export function ClientNav() {
             pipeline: data.counts?.pipelineJobs || 0,
             evaluations: 0,
             "content-generation": data.counts?.creativeDrafts || 0,
+            voc: data.counts?.vocThemes || 0,
             athlete: data.counts?.athleteActivityLogs || 0,
             athletes: data.counts?.athleteActivityLogs || 0,
           });

--- a/src/lib/grounded-answers.ts
+++ b/src/lib/grounded-answers.ts
@@ -44,20 +44,24 @@ function entityLabel(entityType: SearchResultRecord["entityType"]) {
       return "Worker Queue";
     case "WORKFLOW_BLUEPRINT":
       return "Workflow";
+    case "VOC_THEME":
+      return "Customer Theme";
+    case "VOC_ACTION_BRIEF":
+      return "Customer Brief";
   }
 }
 
 function filterByIntent(results: SearchResultRecord[], intent: string) {
   if (intent === "execution") {
-    return results.filter((item) => item.entityType === "TASK" || item.entityType === "PIPELINE_JOB");
+    return results.filter((item) => item.entityType === "TASK" || item.entityType === "PIPELINE_JOB" || item.entityType === "VOC_ACTION_BRIEF");
   }
   if (intent === "strategy") {
-    return results.filter((item) => item.entityType === "GOALCARD" || item.entityType === "TOPIC" || item.entityType === "TASK");
+    return results.filter((item) => item.entityType === "GOALCARD" || item.entityType === "TOPIC" || item.entityType === "TASK" || item.entityType === "VOC_THEME");
   }
   if (intent === "evidence") {
-    return results.filter((item) => item.entityType === "SOURCE" || item.entityType === "FLASHCARD" || item.entityType === "TOPIC");
+    return results.filter((item) => item.entityType === "SOURCE" || item.entityType === "FLASHCARD" || item.entityType === "TOPIC" || item.entityType === "VOC_THEME");
   }
-  return results.filter((item) => item.entityType === "FLASHCARD" || item.entityType === "SOURCE" || item.entityType === "TOPIC");
+  return results.filter((item) => item.entityType === "FLASHCARD" || item.entityType === "SOURCE" || item.entityType === "TOPIC" || item.entityType === "VOC_THEME");
 }
 
 export async function buildGroundedAnswer(companyId: string, question: string) {

--- a/src/lib/internal-search.ts
+++ b/src/lib/internal-search.ts
@@ -7,7 +7,9 @@ export type SearchEntityType =
   | "GOALCARD"
   | "TASK"
   | "PIPELINE_JOB"
-  | "WORKFLOW_BLUEPRINT";
+  | "WORKFLOW_BLUEPRINT"
+  | "VOC_THEME"
+  | "VOC_ACTION_BRIEF";
 
 export type SearchResultRecord = {
   id: string;
@@ -87,6 +89,10 @@ function entityWeight(entityType: SearchEntityType) {
       return 5;
     case "SOURCE":
       return 4;
+    case "VOC_ACTION_BRIEF":
+      return 4;
+    case "VOC_THEME":
+      return 4;
     case "WORKFLOW_BLUEPRINT":
       return 3;
     case "PIPELINE_JOB":
@@ -123,6 +129,8 @@ export async function searchCompanyContext(
         TASK: 0,
         PIPELINE_JOB: 0,
         WORKFLOW_BLUEPRINT: 0,
+        VOC_THEME: 0,
+        VOC_ACTION_BRIEF: 0,
       } satisfies Record<SearchEntityType, number>,
       total: 0,
     } satisfies SearchResponsePayload;
@@ -135,9 +143,11 @@ export async function searchCompanyContext(
     "TASK",
     "PIPELINE_JOB",
     "WORKFLOW_BLUEPRINT",
+    "VOC_THEME",
+    "VOC_ACTION_BRIEF",
   ]);
 
-  const [sources, topics, flashcards, goalcards, tasks, pipelineJobs, workflowBlueprints] = await Promise.all([
+  const [sources, topics, flashcards, goalcards, tasks, pipelineJobs, workflowBlueprints, vocThemes, vocBriefs] = await Promise.all([
     prisma.source.findMany({
       where: { companyId },
       orderBy: [{ updatedAt: "desc" }],
@@ -184,6 +194,16 @@ export async function searchCompanyContext(
       where: { companyId, status: { in: ["ACTIVE", "PAUSED"] } },
       orderBy: [{ updatedAt: "desc" }],
       take: 30,
+    }),
+    prisma.vocTheme.findMany({
+      where: { companyId, status: "ACTIVE" },
+      orderBy: [{ confidence: "desc" }, { updatedAt: "desc" }],
+      take: 40,
+    }),
+    prisma.vocActionBrief.findMany({
+      where: { companyId, status: { in: ["DRAFT", "READY"] } },
+      orderBy: [{ priorityScore: "desc" }, { updatedAt: "desc" }],
+      take: 40,
     }),
   ]);
 
@@ -343,6 +363,50 @@ export async function searchCompanyContext(
     });
   }
 
+  for (const theme of vocThemes) {
+    const score =
+      overlapScore(queryTokens, theme.title, theme.summary, theme.rootCauseHypothesis, theme.affectedSegments.join(" ")) +
+      freshnessBoost(theme.updatedAt) +
+      entityWeight("VOC_THEME");
+    if (score <= 0) continue;
+    results.push({
+      id: theme.id,
+      publicId: null,
+      entityType: "VOC_THEME",
+      title: theme.title,
+      snippet: collapseWhitespace(theme.summary),
+      href: `/${companyId}/voc`,
+      tone: "strategy",
+      iceScore: null,
+      updatedAt: theme.updatedAt.toISOString(),
+      status: theme.reviewState,
+      score,
+      supportingLabel: `${theme.confidence}% confidence`,
+    });
+  }
+
+  for (const brief of vocBriefs) {
+    const score =
+      overlapScore(queryTokens, brief.title, brief.rootCause, brief.recommendedWork, brief.affectedSegment) +
+      freshnessBoost(brief.updatedAt) +
+      entityWeight("VOC_ACTION_BRIEF");
+    if (score <= 0) continue;
+    results.push({
+      id: brief.id,
+      publicId: null,
+      entityType: "VOC_ACTION_BRIEF",
+      title: brief.title,
+      snippet: collapseWhitespace(brief.recommendedWork),
+      href: `/${companyId}/voc`,
+      tone: "checklist",
+      iceScore: null,
+      updatedAt: brief.updatedAt.toISOString(),
+      status: brief.status,
+      score,
+      supportingLabel: `Priority ${Math.round(brief.priorityScore)}`,
+    });
+  }
+
   const filtered = results.filter((item) => allowedTypes.has(item.entityType));
   const counts = filtered.reduce((acc, item) => {
     acc[item.entityType] += 1;
@@ -355,6 +419,8 @@ export async function searchCompanyContext(
     TASK: 0,
     PIPELINE_JOB: 0,
     WORKFLOW_BLUEPRINT: 0,
+    VOC_THEME: 0,
+    VOC_ACTION_BRIEF: 0,
   } satisfies Record<SearchEntityType, number>);
 
   return {

--- a/src/lib/voc-signal-fusion.ts
+++ b/src/lib/voc-signal-fusion.ts
@@ -1,0 +1,200 @@
+import { Prisma } from "@prisma/client";
+
+export type VocChannel = "REVIEW" | "SUPPORT" | "SURVEY" | "SALES" | "SOCIAL" | "CANCELLATION" | "INTERVIEW" | "NOTE";
+export type VocSentiment = "POSITIVE" | "NEUTRAL" | "NEGATIVE" | "MIXED";
+
+export const VOC_CHANNELS: Array<{ value: VocChannel; label: string }> = [
+  { value: "REVIEW", label: "Review" },
+  { value: "SUPPORT", label: "Support" },
+  { value: "SURVEY", label: "Survey" },
+  { value: "SALES", label: "Sales" },
+  { value: "SOCIAL", label: "Social" },
+  { value: "CANCELLATION", label: "Cancellation" },
+  { value: "INTERVIEW", label: "Interview" },
+  { value: "NOTE", label: "Note" },
+];
+
+const SENTIMENTS: VocSentiment[] = ["POSITIVE", "NEUTRAL", "NEGATIVE", "MIXED"];
+
+const THEME_RULES = [
+  {
+    key: "onboarding",
+    title: "Onboarding friction",
+    terms: ["onboard", "setup", "start", "confusing", "activation", "tutorial", "learn"],
+    rootCause: "Customers are not reaching first value quickly or clearly enough.",
+    work: "Review onboarding steps, first-run guidance, and activation messaging.",
+  },
+  {
+    key: "pricing",
+    title: "Pricing or value objection",
+    terms: ["price", "pricing", "expensive", "cost", "budget", "worth", "value"],
+    rootCause: "Perceived value, packaging, or pricing explanation is not strong enough for this segment.",
+    work: "Create a pricing/value objection brief and test clearer packaging or proof points.",
+  },
+  {
+    key: "reliability",
+    title: "Reliability and quality concern",
+    terms: ["bug", "broken", "slow", "crash", "error", "reliable", "quality", "missing"],
+    rootCause: "Customers are encountering quality or performance issues that reduce trust.",
+    work: "Prioritize a reliability repair checklist with supporting customer excerpts.",
+  },
+  {
+    key: "support",
+    title: "Support experience gap",
+    terms: ["support", "help", "reply", "response", "ticket", "service", "agent"],
+    rootCause: "Customers need faster or clearer help paths for unresolved work.",
+    work: "Review support macros, escalation paths, and self-serve help content.",
+  },
+  {
+    key: "feature",
+    title: "Feature request or capability gap",
+    terms: ["feature", "wish", "need", "request", "integration", "export", "report", "dashboard"],
+    rootCause: "A recurring use case is not sufficiently covered by the current product surface.",
+    work: "Create a product opportunity brief that links demand, segment, and expected impact.",
+  },
+];
+
+function cleanText(value: unknown, fallback = "") {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function clampScore(value: unknown, fallback = 3) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return fallback;
+  return Math.max(1, Math.min(5, Math.round(numeric)));
+}
+
+export function normalizeVocChannel(value: unknown): VocChannel {
+  const candidate = String(value || "").toUpperCase();
+  return VOC_CHANNELS.some((item) => item.value === candidate) ? candidate as VocChannel : "NOTE";
+}
+
+export function normalizeVocSentiment(value: unknown): VocSentiment {
+  const candidate = String(value || "").toUpperCase();
+  return SENTIMENTS.includes(candidate as VocSentiment) ? candidate as VocSentiment : "NEUTRAL";
+}
+
+export function normalizeVocSignalInput(data: Record<string, unknown>) {
+  const excerpt = cleanText(data.excerpt || data.body || data.content);
+  const title = cleanText(data.title, excerpt.slice(0, 80) || "Customer signal");
+  return {
+    channel: normalizeVocChannel(data.channel),
+    sourceLabel: cleanText(data.sourceLabel) || undefined,
+    customerSegment: cleanText(data.customerSegment) || undefined,
+    lifecycleStage: cleanText(data.lifecycleStage) || undefined,
+    sentiment: normalizeVocSentiment(data.sentiment),
+    urgency: clampScore(data.urgency),
+    accountValue: Number.isFinite(Number(data.accountValue)) ? Number(data.accountValue) : undefined,
+    title: title.slice(0, 160),
+    excerpt: excerpt.slice(0, 2000),
+    provenanceUrl: cleanText(data.provenanceUrl) || undefined,
+    occurredAt: typeof data.occurredAt === "string" && data.occurredAt ? new Date(data.occurredAt) : new Date(),
+    metadata: typeof data.metadata === "object" && data.metadata && !Array.isArray(data.metadata)
+      ? data.metadata as Prisma.InputJsonValue
+      : {},
+  };
+}
+
+type SignalLike = {
+  id: string;
+  title: string;
+  excerpt: string;
+  channel: string;
+  customerSegment: string | null;
+  lifecycleStage: string | null;
+  sentiment: string;
+  urgency: number;
+  occurredAt: Date;
+};
+
+function matchingRule(signal: SignalLike) {
+  const text = `${signal.title} ${signal.excerpt}`.toLowerCase();
+  return THEME_RULES.find((rule) => rule.terms.some((term) => text.includes(term))) || {
+    key: "general",
+    title: "General customer signal",
+    terms: [],
+    rootCause: "Customers are expressing a recurring need that needs more evidence before deep prioritization.",
+    work: "Collect more customer evidence, then convert the strongest pattern into product, messaging, or support work.",
+  };
+}
+
+function confidenceFor(signals: SignalLike[]) {
+  const recurrence = Math.min(30, signals.length * 10);
+  const urgency = Math.round(signals.reduce((sum, signal) => sum + signal.urgency, 0) / Math.max(1, signals.length)) * 8;
+  const channelSpread = new Set(signals.map((signal) => signal.channel)).size * 5;
+  return Math.max(30, Math.min(95, 25 + recurrence + urgency + channelSpread));
+}
+
+function sentimentMix(signals: SignalLike[]) {
+  return signals.reduce<Record<string, number>>((mix, signal) => {
+    mix[signal.sentiment] = (mix[signal.sentiment] || 0) + 1;
+    return mix;
+  }, {});
+}
+
+export function buildVocThemeCandidates(signals: SignalLike[]) {
+  const grouped = new Map<string, SignalLike[]>();
+  for (const signal of signals) {
+    const rule = matchingRule(signal);
+    grouped.set(rule.key, [...(grouped.get(rule.key) || []), signal]);
+  }
+
+  return Array.from(grouped.entries()).map(([key, items]) => {
+    const rule = THEME_RULES.find((candidate) => candidate.key === key) || matchingRule(items[0]);
+    const segments = Array.from(new Set(items.map((item) => item.customerSegment).filter((value): value is string => Boolean(value)))).slice(0, 6);
+    const excerpts = items.slice(0, 6).map((item) => ({
+      signalId: item.id,
+      channel: item.channel,
+      excerpt: item.excerpt.slice(0, 240),
+      sentiment: item.sentiment,
+      urgency: item.urgency,
+    }));
+    const confidence = confidenceFor(items);
+    const recurrenceScore = Math.min(5, items.length);
+    const impactScore = Math.max(1, Math.min(5, Math.round((confidence / 20 + recurrenceScore) / 2)));
+    const priorityScore = Math.round((impactScore * 30 + confidence + recurrenceScore * 10) / 2);
+
+    return {
+      title: rule.title,
+      summary: `${items.length} customer signal${items.length === 1 ? "" : "s"} point to ${rule.title.toLowerCase()}.`,
+      rootCauseHypothesis: rule.rootCause,
+      affectedSegments: segments,
+      signalIds: items.map((item) => item.id),
+      supportingExcerpts: excerpts,
+      sentimentMix: sentimentMix(items),
+      trendDirection: items.length >= 3 ? "RISING" : "STABLE",
+      confidence,
+      impactScore,
+      recurrenceScore,
+      freshnessScore: 5,
+      reviewState: Object.keys(sentimentMix(items)).length > 2 ? "REVIEW" : "READY",
+      actionBrief: {
+        title: `${rule.title} action brief`,
+        rootCause: rule.rootCause,
+        affectedSegment: segments[0],
+        recommendedWork: rule.work,
+        nextStepType: "CHECKLIST",
+        priorityScore,
+        evidence: excerpts,
+      },
+    };
+  }).sort((a, b) => b.actionBrief.priorityScore - a.actionBrief.priorityScore);
+}
+
+export function summarizeVoc(signals: SignalLike[], themes: Array<{ confidence: number; reviewState: string }>, briefs: Array<{ status: string }>) {
+  const negativeSignals = signals.filter((signal) => signal.sentiment === "NEGATIVE").length;
+  const urgentSignals = signals.filter((signal) => signal.urgency >= 4).length;
+  const avgConfidence = themes.length
+    ? Math.round(themes.reduce((sum, theme) => sum + theme.confidence, 0) / themes.length)
+    : 0;
+  return {
+    totalSignals: signals.length,
+    negativeSignals,
+    urgentSignals,
+    totalThemes: themes.length,
+    reviewThemes: themes.filter((theme) => theme.reviewState === "REVIEW").length,
+    actionBriefs: briefs.length,
+    openBriefs: briefs.filter((brief) => brief.status !== "ARCHIVED").length,
+    averageThemeConfidence: avgConfidence,
+  };
+}


### PR DESCRIPTION
## Summary\n\nImplements the first #174 customer voice slice:\n- adds VocSignal, VocTheme, and VocActionBrief persistence\n- adds deterministic VoC normalization, theme fusion, confidence/review-state scoring, and action-brief generation\n- adds /api/voc and /:companyId/voc for recording customer-language evidence and reviewing themes/briefs\n- adds Customer Voice nav/dashboard counts\n- adds VOC_THEME and VOC_ACTION_BRIEF to Search & Answers and grounded-answer filtering\n- updates README, HANDOVER, SSOT, system design, rulebook, and local pipeline docs\n\nCloses #174 when merged.\n\n## Validation\n\n- npx prisma generate\n- npm run audit:docs\n- npm run audit:semantic\n- npm run lint\n- npx tsc --noEmit\n- local unauthenticated smoke confirmed login gating for /api/voc and /:companyId/voc