### PR TITLE
Implement control-plane board adapter contracts

### DIFF
--- a/docs/INTELLIGENCE_UNIT_CONTROL_PLANE_LLD.md
+++ b/docs/INTELLIGENCE_UNIT_CONTROL_PLANE_LLD.md
@@ -218,6 +218,137 @@ The current implementation supports two compatibility layers at the same time:
 - v3 Block-first runtime capabilities through `src/lib/check-foundation/capabilities-v3.ts`
 - v2 legacy webapp profile/module projection through `src/lib/intelligence-unit-capabilities.ts`
 
+### 6.1 Board adapter registry contract
+
+The board control plane is centralized in `src/lib/board-adapters.ts`.
+No surface may hard-code board identity, entity type, status mapping, or write policy outside this registry.
+
+Registered surfaces:
+
+- `unitBoard` maps `unit-board` to `UNIT_PROJECT` / `BOARD_CARD` and is writable.
+- `aiQueue` maps `pipeline` to `PIPELINE_QUEUE` / `PIPELINE_JOB` and is projection read-only.
+- `goals` maps `goals` to `GOALS` / `GOALCARD` and is projection read-only.
+- `topics` maps `topics` to `TOPICS` / `TOPIC` and is projection read-only.
+- `data` maps `data` to `DATA_SOURCES` / `SOURCE` and is projection read-only.
+- `knowmore` maps `knowmore` to `KNOWMORE` / `KNOWMORE_PACKET` and is projection read-only.
+- `review` maps `review` to `REVIEW` / `REVIEW_ITEM` and is projection read-only.
+- `tactical` maps `tactical` to `TACTICAL` / `TACTICAL_TASK` and is projection read-only.
+- `sales` maps `sales` to `SALES` / `OPPORTUNITYCARD` and is projection read-only.
+
+Resolution order:
+
+1. `surface`
+2. `module`
+3. `boardKey`
+4. `entityType`
+5. legacy default
+6. read-only fallback
+
+Legacy default applies only when no selector is provided.
+Explicit unsupported combinations must not silently become writable.
+They recover to a read-only `UNIT_PROJECT` fallback with `adapter.diagnostics.reasonCode = "board-adapter-module-fallback"`.
+
+### 6.2 Board adapter runtime flow
+
+`GET /api/board-items` resolves an adapter before reading cards and states.
+The response preserves the existing `items`, `columns`, and `traceId` fields and adds:
+
+```json
+{
+  "adapter": {
+    "surface": "goals",
+    "module": "goals",
+    "boardKey": "GOALS",
+    "entityType": "GOALCARD",
+    "allowWrite": false,
+    "resolvedBy": "module",
+    "diagnostics": {
+      "reasonCode": "board-adapter-resolved",
+      "retryable": false,
+      "recovered": false,
+      "warnings": []
+    }
+  }
+}
+```
+
+`POST`, `PATCH`, and `DELETE` must reject read-only adapters before persistence.
+The error payload must include `adapter.diagnostics` so the caller can distinguish expected read-only projection behavior from a broken board.
+
+### 6.3 Status adapter and domain-row mapping
+
+All module surfaces normalize source states through `normalizeBoardTargetForModule(module, status)`.
+Known states map deterministically to board columns:
+
+- queued, ready, and todo map to `TODO`
+- active, running, processing, and in-progress map to `IN_PROGRESS`
+- blocked, failed, and retrying map to `BLOCKED`
+- done, complete, completed, and published map to `DONE`
+- missing or unknown states map to the first configured adapter column
+
+Domain records must pass through `adaptDomainRowToBoardCard(module, row)` before rendering in a board surface.
+The adapter stores source evidence in `metadata.sourceRow`, `metadata.sourceStatus`, and `metadata.sourceEntityType`.
+
+### 6.4 Observability, retries, and recovery
+
+Every adapter resolution can produce a `BOARD_ADAPTER_RESOLUTION` telemetry payload with:
+
+- `unitId`
+- `companyId`
+- `surface`
+- `module`
+- `boardKey`
+- `sourceProfile`
+- `targetProfile`
+- `capabilitiesVersion`
+- `reasonCode`
+- `retryable`
+- `recovered`
+- `warnings`
+
+Operational behavior:
+
+- `board-adapter-resolved` is normal and non-retryable.
+- `board-adapter-legacy-default` is recovered compatibility behavior and should be removed only after all callers provide selectors.
+- `board-adapter-module-fallback` is recovered, retryable configuration drift and must show an operator-visible fallback notice.
+- Read-only adapter writes are rejected without partial persistence.
+- Fallback writes are rejected before database mutation, making rollback a no-op.
+- Recovery is to send a supported `surface`, `module`, `boardKey`, or `entityType` selector.
+
+### 6.5 Capability control transaction contract
+
+Capability changes use the transaction route, not direct settings mutation.
+The response must expose:
+
+- `version`
+- `resolutionSource`
+- `effectiveProfile`
+- `effectiveModules`
+- `changedBy`
+- `effective`
+- `warnings`
+- `errors`
+- `impact`
+- optional `runtime`
+
+UI states must support loading, dirty, save success, save failure, validation blocked, and read-only.
+Critical disables must be presented as explicit operator intent and persisted through `uiIntent`.
+The telemetry event for surface mutation remains `UNIT_SURFACE_UPDATE`.
+
+### 6.6 Regression and release gate
+
+`npm run test:control-plane-board-adapters` is the source-level contract harness for issues #288 through #292.
+It verifies:
+
+- every required module adapter is registered
+- fallback diagnostics are explicit
+- board API responses expose `adapter.diagnostics`
+- write rejection paths include diagnostics
+- capability transaction responses carry operator-facing resolution metadata
+- this LLD documents telemetry and recovery behavior
+
+The harness is intentionally database-free so it can run in CI before integration fixtures exist.
+
 Delivery rules:
 
 - `profile` and legacy `webappProfile` must both normalize into the same `UnitWebappProfile` contract

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:check-foundation-permissions": "node scripts/test-check-foundation-permissions-audit.mjs",
     "test:check-foundation-block-runtime": "node scripts/test-check-foundation-block-runtime-contracts.mjs",
     "test:capability-transaction": "node scripts/test-capability-transaction-contract.mjs",
+    "test:control-plane-board-adapters": "node scripts/test-control-plane-board-adapters.mjs",
     "test:unit-capability-v2": "node scripts/test-unit-capability-v2-contract.mjs",
     "test:unit-crud": "node scripts/test-unit-crud-contract.mjs",
     "test:intelligence-unit-refactor": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/test-intelligence-unit-refactor-contracts.mjs",

--- a/scripts/test-control-plane-board-adapters.mjs
+++ b/scripts/test-control-plane-board-adapters.mjs
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.cwd();
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function assertIncludes(source, needle, label) {
+  if (!source.includes(needle)) {
+    throw new Error(`${label}: expected ${needle}`);
+  }
+}
+
+function assertPattern(source, pattern, label) {
+  if (!pattern.test(source)) {
+    throw new Error(`${label}: expected ${pattern}`);
+  }
+}
+
+const adapters = read("src/lib/board-adapters.ts");
+const route = read("src/app/api/board-items/route.ts");
+const capabilityRoute = read("src/app/api/companies/[companyId]/capabilities/transaction/route.ts");
+const docs = read("docs/INTELLIGENCE_UNIT_CONTROL_PLANE_LLD.md");
+
+[
+  '"unitBoard"',
+  '"aiQueue"',
+  '"goals"',
+  '"topics"',
+  '"data"',
+  '"knowmore"',
+  '"review"',
+  '"tactical"',
+  '"sales"',
+].forEach((surface) => assertIncludes(adapters, surface, `adapter surface ${surface}`));
+
+[
+  'module: "unit-board"',
+  'module: "pipeline"',
+  'module: "goals"',
+  'module: "topics"',
+  'module: "data"',
+  'module: "knowmore"',
+  'module: "review"',
+  'module: "tactical"',
+  'module: "sales"',
+].forEach((module) => assertIncludes(adapters, module, `adapter module ${module}`));
+
+[
+  "export function listBoardAdapters",
+  "export function resolveBoardAdapterDiagnostics",
+  "export function normalizeBoardTargetForModule",
+  "export function adaptDomainRowToBoardCard",
+  "export function buildBoardAdapterTelemetry",
+  "board-adapter-module-fallback",
+  "Unsupported board adapter combination resolved to read-only unit board fallback.",
+].forEach((needle) => assertIncludes(adapters, needle, "adapter registry contract"));
+
+assertPattern(route, /adapter:\s*\{\s*surface:\s*adapter\.surface/s, "board API exposes adapter surface");
+assertIncludes(route, "diagnostics: adapter.diagnostics", "board API exposes diagnostics");
+assertIncludes(route, "buildBoardAdapterTelemetry(adapter", "board API emits telemetry payload");
+assertIncludes(route, "adapter.diagnostics", "board API write errors expose diagnostics");
+
+[
+  "version: string;",
+  "resolutionSource:",
+  "effectiveProfile:",
+  "effectiveModules: string[];",
+  "changedBy?:",
+].forEach((needle) => assertIncludes(capabilityRoute, needle, "capability transaction response fields"));
+
+[
+  "Board adapter registry contract",
+  "BOARD_ADAPTER_RESOLUTION",
+  "board-adapter-module-fallback",
+  "adapter.diagnostics",
+].forEach((needle) => assertIncludes(docs, needle, "control-plane adapter documentation"));
+
+console.log("Control-plane board adapter contract passed");

--- a/src/app/api/board-items/route.ts
+++ b/src/app/api/board-items/route.ts
@@ -4,7 +4,11 @@ import { verifyMembership } from "@/lib/permissions";
 import { BOARD_RANK_STEP, PROJECT_BOARD_COLUMNS, sortBoardRecords } from "@/lib/board-system";
 import { buildNormalizedRanks, computeServerBoardRank, needsBoardRebalance } from "@/lib/board-rank";
 import { classifyPersistenceFailure } from "@/lib/persistence-failures";
-import { resolveBoardAdapter, type ResolvedBoardAdapter } from "@/lib/board-adapters";
+import {
+  buildBoardAdapterTelemetry,
+  resolveBoardAdapter,
+  type ResolvedBoardAdapter,
+} from "@/lib/board-adapters";
 
 export const dynamic = "force-dynamic";
 
@@ -303,9 +307,11 @@ export async function GET(request: NextRequest) {
       const activeCardCount = cards.length;
       const mismatchCount = allCards.length - activeCardCount;
       const withStateCount = items.length;
+      const adapterTelemetry = buildBoardAdapterTelemetry(adapter, { companyId });
       console.info(`[API:BOARD_ITEMS][${traceId}] GET`, {
         companyId,
         boardKey,
+        adapter: adapterTelemetry,
         durationMs: Date.now() - startedAt,
         requested: allCards.length,
         active: activeCardCount,
@@ -315,10 +321,23 @@ export async function GET(request: NextRequest) {
       });
     }
 
+    if (adapter.diagnostics.warnings.length) {
+      console.warn("[API:BOARD_ITEMS] adapter fallback", buildBoardAdapterTelemetry(adapter, { companyId }));
+    }
+
     const response = NextResponse.json({
       items,
       columns: adapter.columns,
       traceId,
+      adapter: {
+        surface: adapter.surface,
+        module: adapter.module,
+        boardKey: adapter.boardKey,
+        entityType: adapter.config.entityType,
+        allowWrite: adapter.allowWrite,
+        resolvedBy: adapter.resolvedBy,
+        diagnostics: adapter.diagnostics,
+      },
     });
     withBoardTrace(response, traceId, debugTrace);
     return response;
@@ -351,7 +370,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "companyId and title are required" }, { status: 400 });
     }
     if (!adapter.allowWrite) {
-      return buildRequestErrorPayload("Board writes are disabled for this surface", "This board surface is read-only.", traceId);
+      return buildRequestErrorPayload("Board writes are disabled for this surface", adapter.diagnostics, traceId);
     }
 
     const actor = auth.membership.id || auth.session.email || "webapp-user";
@@ -428,7 +447,7 @@ export async function PATCH(request: NextRequest) {
     const traceId = getBoardTraceId(request);
     const debugTrace = shouldTraceBoardItems(request);
     if (!adapter.allowWrite) {
-      return buildRequestErrorPayload("Board writes are disabled for this surface", "This board surface is read-only.", traceId);
+      return buildRequestErrorPayload("Board writes are disabled for this surface", adapter.diagnostics, traceId);
     }
     const requestedPriority = normalizeBoardPriority(payload.priority);
     const requestedMetadata = extractMetadata(payload);
@@ -613,7 +632,7 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: "companyId and id are required" }, { status: 400 });
     }
     if (!adapter.allowWrite) {
-      return buildRequestErrorPayload("Board writes are disabled for this surface", "This board surface is read-only.", traceId);
+      return buildRequestErrorPayload("Board writes are disabled for this surface", adapter.diagnostics, traceId);
     }
 
     const existing = await prisma.boardCard.findUnique({ where: { id } });

--- a/src/lib/board-adapters.ts
+++ b/src/lib/board-adapters.ts
@@ -1,82 +1,424 @@
-import type { BoardColumn } from "@/lib/board-system";
-import { PROJECT_BOARD_COLUMNS } from "@/lib/board-system";
-import { SURFACE_BOARD_CONFIG, type SurfaceBoardConfig } from "@/lib/board-state";
+import { PROJECT_BOARD_COLUMNS, type BoardColumn } from "./board-system";
 
-export type BoardSurfaceKey = "unitBoard";
+export type BoardSurfaceKey =
+  | "unitBoard"
+  | "aiQueue"
+  | "goals"
+  | "topics"
+  | "data"
+  | "knowmore"
+  | "review"
+  | "tactical"
+  | "sales";
+
+export type BoardModuleKey =
+  | "unit-board"
+  | "pipeline"
+  | "goals"
+  | "topics"
+  | "data"
+  | "knowmore"
+  | "review"
+  | "tactical"
+  | "sales";
+
+export type BoardAdapterResolutionSource =
+  | "surface"
+  | "module"
+  | "boardKey"
+  | "entityType"
+  | "legacy-default"
+  | "fallback";
+
+export type BoardAdapterReasonCode =
+  | "board-adapter-resolved"
+  | "board-adapter-legacy-default"
+  | "board-adapter-module-fallback"
+  | "board-adapter-unsupported-combination";
+
+export type BoardAdapterConfig = {
+  surface: BoardSurfaceKey;
+  module: BoardModuleKey;
+  boardKey: string;
+  entityType: string;
+  sourceProfile: "NONE" | "CLASSSCOUT" | "COMPARE" | "ANY";
+  targetProfile: "NONE" | "CLASSSCOUT" | "COMPARE" | "ANY";
+  allowWrite: boolean;
+  columns: BoardColumn[];
+  aliases: string[];
+  statusMap: Record<string, string>;
+};
+
+export type BoardAdapterDiagnostics = {
+  reasonCode: BoardAdapterReasonCode;
+  retryable: boolean;
+  recovered: boolean;
+  warnings: string[];
+  requested: {
+    surface?: string;
+    module?: string;
+    boardKey?: string;
+    entityType?: string;
+  };
+};
 
 export type ResolvedBoardAdapter = {
   surface: BoardSurfaceKey;
-  config: SurfaceBoardConfig;
+  module: BoardModuleKey;
+  config: BoardAdapterConfig;
   boardKey: string;
   columns: BoardColumn[];
   allowWrite: boolean;
+  resolvedBy: BoardAdapterResolutionSource;
+  diagnostics: BoardAdapterDiagnostics;
 };
 
-const SURFACE_COLUMN_MAP: Record<BoardSurfaceKey, BoardColumn[]> = {
-  unitBoard: PROJECT_BOARD_COLUMNS,
+export type BoardAdapterTelemetryPayload = {
+  event: "BOARD_ADAPTER_RESOLUTION";
+  unitId?: string;
+  companyId?: string;
+  surface: BoardSurfaceKey;
+  module: BoardModuleKey;
+  boardKey: string;
+  sourceProfile: BoardAdapterConfig["sourceProfile"];
+  targetProfile: BoardAdapterConfig["targetProfile"];
+  capabilitiesVersion?: string;
+  reasonCode: BoardAdapterReasonCode;
+  retryable: boolean;
+  recovered: boolean;
+  warnings: string[];
 };
 
-const BOARD_KEY_TO_SURFACE: Record<string, BoardSurfaceKey> = {
-  UNIT_PROJECT: "unitBoard",
+export type AdaptedBoardCardProjection = {
+  id: string;
+  title: string;
+  description: string;
+  priority: string;
+  columnKey: string;
+  metadata: Record<string, unknown>;
 };
 
-const SURFACE_BY_MODULE: Record<string, BoardSurfaceKey> = {
-  unitboard: "unitBoard",
-  "unit-board": "unitBoard",
-  unit: "unitBoard",
-  "project-board": "unitBoard",
-  "unit-project": "unitBoard",
+type BoardAdapterInput = URLSearchParams | Record<string, unknown> | null | undefined;
+
+const DEFAULT_STATUS_MAP: Record<string, string> = {
+  backlog: "BACKLOG",
+  todo: "TODO",
+  queued: "TODO",
+  ready: "TODO",
+  active: "IN_PROGRESS",
+  running: "IN_PROGRESS",
+  processing: "IN_PROGRESS",
+  in_progress: "IN_PROGRESS",
+  "in-progress": "IN_PROGRESS",
+  blocked: "BLOCKED",
+  failed: "BLOCKED",
+  retrying: "BLOCKED",
+  done: "DONE",
+  complete: "DONE",
+  completed: "DONE",
+  published: "DONE",
 };
 
-const SURFACE_ALIASES = {
-  ...SURFACE_BY_MODULE,
-  ...Object.fromEntries(
-    Object.entries(BOARD_KEY_TO_SURFACE).map(([key, surface]) => [key.toLowerCase(), surface]),
-  ),
-} satisfies Record<string, BoardSurfaceKey>;
+const UNIT_BOARD_CONFIG: BoardAdapterConfig = {
+  surface: "unitBoard",
+  module: "unit-board",
+  boardKey: "UNIT_PROJECT",
+  entityType: "BOARD_CARD",
+  sourceProfile: "ANY",
+  targetProfile: "ANY",
+  allowWrite: true,
+  columns: PROJECT_BOARD_COLUMNS,
+  aliases: ["unitBoard", "unit-board", "unit_board", "UNIT_PROJECT"],
+  statusMap: DEFAULT_STATUS_MAP,
+};
 
-function normalizeBoardSurfaceToken(value?: unknown): BoardSurfaceKey | null {
-  if (typeof value !== "string") return null;
-  const normalized = value.trim().toLowerCase().replace(/\s+/g, "");
-  if (!normalized) return null;
-  return SURFACE_ALIASES[normalized] ?? null;
+const BOARD_ADAPTERS: BoardAdapterConfig[] = [
+  UNIT_BOARD_CONFIG,
+  {
+    surface: "aiQueue",
+    module: "pipeline",
+    boardKey: "PIPELINE_QUEUE",
+    entityType: "PIPELINE_JOB",
+    sourceProfile: "ANY",
+    targetProfile: "ANY",
+    allowWrite: false,
+    columns: PROJECT_BOARD_COLUMNS,
+    aliases: ["aiQueue", "ai-queue", "pipeline", "PIPELINE_QUEUE", "PIPELINE_JOB"],
+    statusMap: DEFAULT_STATUS_MAP,
+  },
+  {
+    surface: "goals",
+    module: "goals",
+    boardKey: "GOALS",
+    entityType: "GOALCARD",
+    sourceProfile: "ANY",
+    targetProfile: "ANY",
+    allowWrite: false,
+    columns: PROJECT_BOARD_COLUMNS,
+    aliases: ["goals", "GOALS", "GOALCARD"],
+    statusMap: DEFAULT_STATUS_MAP,
+  },
+  {
+    surface: "topics",
+    module: "topics",
+    boardKey: "TOPICS",
+    entityType: "TOPIC",
+    sourceProfile: "ANY",
+    targetProfile: "ANY",
+    allowWrite: false,
+    columns: PROJECT_BOARD_COLUMNS,
+    aliases: ["topics", "TOPICS", "TOPIC"],
+    statusMap: DEFAULT_STATUS_MAP,
+  },
+  {
+    surface: "data",
+    module: "data",
+    boardKey: "DATA_SOURCES",
+    entityType: "SOURCE",
+    sourceProfile: "ANY",
+    targetProfile: "ANY",
+    allowWrite: false,
+    columns: PROJECT_BOARD_COLUMNS,
+    aliases: ["data", "sources", "DATA_SOURCES", "SOURCE"],
+    statusMap: DEFAULT_STATUS_MAP,
+  },
+  {
+    surface: "knowmore",
+    module: "knowmore",
+    boardKey: "KNOWMORE",
+    entityType: "KNOWMORE_PACKET",
+    sourceProfile: "ANY",
+    targetProfile: "ANY",
+    allowWrite: false,
+    columns: PROJECT_BOARD_COLUMNS,
+    aliases: ["knowmore", "know-more", "KNOWMORE", "KNOWMORE_PACKET"],
+    statusMap: DEFAULT_STATUS_MAP,
+  },
+  {
+    surface: "review",
+    module: "review",
+    boardKey: "REVIEW",
+    entityType: "REVIEW_ITEM",
+    sourceProfile: "ANY",
+    targetProfile: "ANY",
+    allowWrite: false,
+    columns: PROJECT_BOARD_COLUMNS,
+    aliases: ["review", "REVIEW", "REVIEW_ITEM"],
+    statusMap: DEFAULT_STATUS_MAP,
+  },
+  {
+    surface: "tactical",
+    module: "tactical",
+    boardKey: "TACTICAL",
+    entityType: "TACTICAL_TASK",
+    sourceProfile: "ANY",
+    targetProfile: "ANY",
+    allowWrite: false,
+    columns: PROJECT_BOARD_COLUMNS,
+    aliases: ["tactical", "TACTICAL", "TACTICAL_TASK"],
+    statusMap: DEFAULT_STATUS_MAP,
+  },
+  {
+    surface: "sales",
+    module: "sales",
+    boardKey: "SALES",
+    entityType: "OPPORTUNITYCARD",
+    sourceProfile: "ANY",
+    targetProfile: "ANY",
+    allowWrite: false,
+    columns: PROJECT_BOARD_COLUMNS,
+    aliases: ["sales", "SALES", "OPPORTUNITYCARD"],
+    statusMap: DEFAULT_STATUS_MAP,
+  },
+];
+
+function readInput(input: BoardAdapterInput, key: string): string | undefined {
+  if (!input) return undefined;
+  if (input instanceof URLSearchParams) {
+    return input.get(key) ?? undefined;
+  }
+  const value = input[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
-function getDefaultReadWriteSupport(surface: BoardSurfaceKey) {
-  // The board-items route is Project Block-only; all valid surfaces map to unitBoard.
-  return surface === "unitBoard";
+function normalizeLookup(value: string | undefined): string | null {
+  return value ? value.trim().toLowerCase() : null;
 }
 
-export function resolveBoardAdapter(input: { boardKey?: string | null; module?: string | null }): ResolvedBoardAdapter {
-  const moduleSurface = normalizeBoardSurfaceToken(input.module);
-  if (moduleSurface) {
-    return {
-      surface: moduleSurface,
-      config: SURFACE_BOARD_CONFIG[moduleSurface],
-      boardKey: SURFACE_BOARD_CONFIG[moduleSurface].boardKey,
-      columns: SURFACE_COLUMN_MAP[moduleSurface],
-      allowWrite: getDefaultReadWriteSupport(moduleSurface),
-    } satisfies ResolvedBoardAdapter;
-  }
-
-  const boardKey = typeof input.boardKey === "string" ? input.boardKey.trim().toUpperCase() : null;
-  const byBoardKey = boardKey ? BOARD_KEY_TO_SURFACE[boardKey] : null;
-  if (byBoardKey) {
-    return {
-      surface: byBoardKey,
-      config: SURFACE_BOARD_CONFIG[byBoardKey],
-      boardKey: SURFACE_BOARD_CONFIG[byBoardKey].boardKey,
-      columns: SURFACE_COLUMN_MAP[byBoardKey],
-      allowWrite: getDefaultReadWriteSupport(byBoardKey),
-    } satisfies ResolvedBoardAdapter;
-  }
-
-  // Backward-compatible default for legacy unit-board clients missing board/module input.
+function buildDiagnostics(
+  input: BoardAdapterInput,
+  reasonCode: BoardAdapterReasonCode,
+  warnings: string[] = [],
+): BoardAdapterDiagnostics {
   return {
-    surface: "unitBoard",
-    config: SURFACE_BOARD_CONFIG.unitBoard,
-    boardKey: SURFACE_BOARD_CONFIG.unitBoard.boardKey,
-    columns: SURFACE_COLUMN_MAP.unitBoard,
-    allowWrite: true,
+    reasonCode,
+    retryable: reasonCode === "board-adapter-module-fallback",
+    recovered: reasonCode === "board-adapter-module-fallback" || reasonCode === "board-adapter-legacy-default",
+    warnings,
+    requested: {
+      surface: readInput(input, "surface"),
+      module: readInput(input, "module"),
+      boardKey: readInput(input, "boardKey"),
+      entityType: readInput(input, "entityType"),
+    },
+  };
+}
+
+function resolveByAlias(value: string | undefined): BoardAdapterConfig | null {
+  const lookup = normalizeLookup(value);
+  if (!lookup) return null;
+  return BOARD_ADAPTERS.find((adapter) => adapter.aliases.some((alias) => alias.toLowerCase() === lookup)) ?? null;
+}
+
+function resolveByField<K extends keyof Pick<BoardAdapterConfig, "surface" | "module" | "boardKey" | "entityType">>(
+  field: K,
+  value: string | undefined,
+): BoardAdapterConfig | null {
+  const lookup = normalizeLookup(value);
+  if (!lookup) return null;
+  return BOARD_ADAPTERS.find((adapter) => String(adapter[field]).toLowerCase() === lookup) ?? null;
+}
+
+function toResolvedBoardAdapter(
+  config: BoardAdapterConfig,
+  input: BoardAdapterInput,
+  resolvedBy: BoardAdapterResolutionSource,
+  diagnostics: BoardAdapterDiagnostics,
+): ResolvedBoardAdapter {
+  return {
+    surface: config.surface,
+    module: config.module,
+    config,
+    boardKey: config.boardKey,
+    columns: config.columns,
+    allowWrite: config.allowWrite,
+    resolvedBy,
+    diagnostics,
+  };
+}
+
+export function listBoardAdapters(): BoardAdapterConfig[] {
+  return BOARD_ADAPTERS.map((adapter) => ({ ...adapter, columns: [...adapter.columns], aliases: [...adapter.aliases] }));
+}
+
+export function resolveBoardAdapter(input: BoardAdapterInput = null): ResolvedBoardAdapter {
+  const explicitSurface = readInput(input, "surface");
+  const explicitModule = readInput(input, "module");
+  const explicitBoardKey = readInput(input, "boardKey");
+  const explicitEntityType = readInput(input, "entityType");
+
+  const bySurface = resolveByField("surface", explicitSurface) ?? resolveByAlias(explicitSurface);
+  if (bySurface) {
+    return toResolvedBoardAdapter(bySurface, input, "surface", buildDiagnostics(input, "board-adapter-resolved"));
+  }
+
+  const byModule = resolveByField("module", explicitModule) ?? resolveByAlias(explicitModule);
+  if (byModule) {
+    return toResolvedBoardAdapter(byModule, input, "module", buildDiagnostics(input, "board-adapter-resolved"));
+  }
+
+  const byBoardKey = resolveByField("boardKey", explicitBoardKey) ?? resolveByAlias(explicitBoardKey);
+  if (byBoardKey) {
+    return toResolvedBoardAdapter(byBoardKey, input, "boardKey", buildDiagnostics(input, "board-adapter-resolved"));
+  }
+
+  const byEntityType = resolveByField("entityType", explicitEntityType) ?? resolveByAlias(explicitEntityType);
+  if (byEntityType) {
+    return toResolvedBoardAdapter(byEntityType, input, "entityType", buildDiagnostics(input, "board-adapter-resolved"));
+  }
+
+  if (explicitSurface || explicitModule || explicitBoardKey || explicitEntityType) {
+    const fallbackConfig: BoardAdapterConfig = {
+      ...UNIT_BOARD_CONFIG,
+      allowWrite: false,
+    };
+    return toResolvedBoardAdapter(
+      fallbackConfig,
+      input,
+      "fallback",
+      buildDiagnostics(input, "board-adapter-module-fallback", [
+        "Unsupported board adapter combination resolved to read-only unit board fallback.",
+      ]),
+    );
+  }
+
+  return toResolvedBoardAdapter(
+    UNIT_BOARD_CONFIG,
+    input,
+    "legacy-default",
+    buildDiagnostics(input, "board-adapter-legacy-default", [
+      "No board adapter selector was provided; legacy unit-board default was used.",
+    ]),
+  );
+}
+
+export function resolveBoardAdapterDiagnostics(input: BoardAdapterInput = null): BoardAdapterDiagnostics {
+  return resolveBoardAdapter(input).diagnostics;
+}
+
+export function normalizeBoardTargetForModule(module: string, rawStatus: string | null | undefined): string {
+  const adapter = resolveBoardAdapter({ module });
+  const status = normalizeLookup(rawStatus ?? undefined);
+  if (!status) {
+    return adapter.columns[0]?.key ?? "BACKLOG";
+  }
+  return adapter.config.statusMap[status] ?? adapter.columns[0]?.key ?? "BACKLOG";
+}
+
+export function adaptDomainRowToBoardCard(
+  module: string,
+  row: Record<string, unknown>,
+): AdaptedBoardCardProjection {
+  const id = typeof row.id === "string" ? row.id : `${module}:${String(row.slug ?? row.name ?? "unknown")}`;
+  const title = typeof row.title === "string"
+    ? row.title
+    : typeof row.name === "string"
+      ? row.name
+      : id;
+  const description = typeof row.description === "string"
+    ? row.description
+    : typeof row.summary === "string"
+      ? row.summary
+      : "";
+  const priority = typeof row.priority === "string" ? row.priority : "normal";
+  const status = typeof row.status === "string" ? row.status : typeof row.state === "string" ? row.state : null;
+
+  return {
+    id,
+    title,
+    description,
+    priority,
+    columnKey: normalizeBoardTargetForModule(module, status),
+    metadata: {
+      module,
+      sourceStatus: status,
+      sourceEntityType: resolveBoardAdapter({ module }).config.entityType,
+      sourceRow: row,
+    },
+  };
+}
+
+export function buildBoardAdapterTelemetry(
+  adapter: ResolvedBoardAdapter,
+  context: {
+    unitId?: string;
+    companyId?: string;
+    capabilitiesVersion?: string;
+  } = {},
+): BoardAdapterTelemetryPayload {
+  return {
+    event: "BOARD_ADAPTER_RESOLUTION",
+    unitId: context.unitId,
+    companyId: context.companyId,
+    surface: adapter.surface,
+    module: adapter.module,
+    boardKey: adapter.boardKey,
+    sourceProfile: adapter.config.sourceProfile,
+    targetProfile: adapter.config.targetProfile,
+    capabilitiesVersion: context.capabilitiesVersion,
+    reasonCode: adapter.diagnostics.reasonCode,
+    retryable: adapter.diagnostics.retryable,
+    recovered: adapter.diagnostics.recovered,
+    warnings: adapter.diagnostics.warnings,
   };
 }


### PR DESCRIPTION
## Scope
Implements the next five Intelligence Unit Control Plane issues:

- Closes #288
- Closes #289
- Closes #290
- Closes #291
- Closes #292

## Implementation
- Adds a centralized board adapter registry for unitBoard, aiQueue/pipeline, goals, topics, data, knowmore, review, tactical, and sales.
- Preserves legacy writable UNIT_PROJECT behavior when no selector is supplied.
- Converts unsupported explicit adapter selections into read-only fallback with diagnostics instead of silent writes.
- Exposes adapter metadata and diagnostics in /api/board-items responses and read-only write failures.
- Adds deterministic domain status normalization and board-card projection helpers.
- Adds BOARD_ADAPTER_RESOLUTION telemetry payload construction.
- Adds a database-free regression harness and documents runtime, rollback, recovery, testing, and operational behavior in the control-plane LLD.

## Validation
- npm run test:control-plane-board-adapters
- npm run test:capability-transaction
- npm run test:intelligence-unit-refactor
- npm run build
