### PR TITLE
Implement lifecycle automation spine contracts

### DIFF
--- a/docs/CHECK_LIFECYCLE_AUTOMATION_LLD.md
+++ b/docs/CHECK_LIFECYCLE_AUTOMATION_LLD.md
@@ -1,0 +1,273 @@
+# CHECK Lifecycle Automation LLD
+
+This document defines the production contract for the lifecycle automation slice covering provisioning, maintenance, destination daemon scheduling, Visitor content maintenance, and feedback learning.
+
+It follows the quality structure required by sovereignsquad/general-design-system#81.
+
+## Scope
+
+- #353 Provisioning engine
+- #354 Maintenance engine
+- #355 Destination mission daemon
+- #356 Visitor existing content maintenance
+- #357 Feedback learning loop
+
+## Architecture
+
+Lifecycle automation is split into two layers:
+
+- Pure contract layer: `src/lib/check-lifecycle/lifecycle-spine.js`
+- Database/runtime layer: existing provisioning, maintenance, queue, daemon, and Visitor modules
+
+The pure layer is deterministic and database-free. Runtime code consumes it to keep repair behavior predictable and testable.
+
+## Runtime flow
+
+Provisioning:
+
+1. Build a provisioning plan from Unit profile and destination keys.
+2. Create or verify the Unit.
+3. Ensure required pipeline jobs.
+4. Ensure destination instances.
+5. Ensure active mission definitions.
+6. Mark topology/projections dirty.
+7. Record audit event or compensating audit event on rollback.
+
+Maintenance:
+
+1. Select a bounded Unit shard.
+2. Infer active destination keys.
+3. Compare actual jobs, missions, daemon lanes, public projections, and memory state against topology requirements.
+4. Apply safe repairs inline.
+5. Queue heavy repairs such as public verification.
+6. Return `lifecycleHealth`, `daemonLane`, and `telemetry`.
+
+Destination daemon:
+
+1. Resolve mission kinds through lifecycle topology.
+2. Use one destination-agnostic daemon identity: `DESTINATION_MISSION_DAEMON` / `DESTINATION_SERVICE` / `destination-service`.
+3. Store lane metadata with `destinationKeys`, `missionKinds`, `activeDefinitionIds`, `activeRunIds`, and `serviceLane`.
+4. Keep ClassScout `rulebook_new_listing` and Compare `VISITOR_CONTENT_CURATION` in the same scheduling contract.
+
+Visitor content maintenance:
+
+1. Score source trust, freshness, taxonomy fit, evidence completeness, and feedback fit.
+2. Apply hard blocks before any publish decision.
+3. Block source-only, missing-source-evidence, forbidden-category, and fake/placeholder content.
+4. Queue review, verification, retirement, or publish based on deterministic state.
+
+Feedback learning:
+
+1. Normalize operator feedback into rules.
+2. Apply severity precedence: `block > retire > require_review > warn`.
+3. Attach rules to candidate review and existing content maintenance.
+4. Trigger refinement when rules affect future or already published content.
+
+## Contracts
+
+### Provisioning plan
+
+`buildProvisioningPlan(input)` returns:
+
+- `schemaVersion`
+- `type`
+- `destinationKeys`
+- `requirements`
+- `steps`
+- `created`
+- `repaired`
+- `skipped`
+- `failed`
+
+Every step includes:
+
+- `id`
+- `operation`
+- `status`
+- `retryable`
+- `rollback`
+- `summary`
+- `metadata`
+
+### Maintenance diff
+
+`buildMaintenanceDiff(input)` returns:
+
+- `state`: `healthy`, `repairing`, `blocked`, or `paused_low_memory`
+- `reasonCode`
+- `operatorMessage`
+- `safeRepairs`
+- `heavyRepairs`
+- `failures`
+- `metrics`
+
+Reason codes include:
+
+- `missing_pipeline_job`
+- `missing_daemon_lane`
+- `missing_mission_definition`
+- `stale_mission_kind`
+- `stale_public_projection`
+- `paused_low_memory`
+
+### Daemon lane metadata
+
+`buildDestinationDaemonLane(input)` returns:
+
+- `jobType`
+- `entityType`
+- `entityId`
+- `metadata.destinationKeys`
+- `metadata.missionKinds`
+- `metadata.activeDefinitionIds`
+- `metadata.activeRunIds`
+- `metadata.serviceLane`
+- `metadata.sourceSignal`
+
+### Visitor content health
+
+`scoreVisitorContentHealth(input)` returns:
+
+- `score`
+- `state`
+- `publishEligible`
+- `hardBlocks`
+- `recoveryAction`
+
+The score is:
+
+`S = 0.35*sourceTrust + 0.25*freshness + 0.20*taxonomyFit + 0.15*evidenceCompleteness + 0.05*feedbackFit`
+
+Any hard block forces `S = 0` and `publishEligible = false`.
+
+### Feedback policy
+
+`normalizeVisitorFeedbackDecision(decision)` creates durable rule payloads.
+
+`evaluateVisitorFeedbackPolicy({ candidate, rules })` returns:
+
+- `decision`
+- `severity`
+- `matchedRules`
+- `publishEligible`
+- `refinementRequired`
+
+## APIs
+
+Existing public/internal APIs stay in place for this slice.
+
+Runtime services should expose the new lifecycle payloads where available:
+
+- `POST /api/companies`
+- `POST /api/companies/[companyId]/capabilities/transaction`
+- lifecycle maintenance CLI and worker output
+- destination mission daemon responses
+- Visitor ops snapshots
+- Visitor feedback/review routes
+
+## UX states
+
+Operator-facing states:
+
+- loading
+- healthy
+- repairing
+- degraded
+- blocked
+- paused low memory
+- retrying
+- repaired
+- failed terminal
+
+No UI was introduced in this slice. Future UI work must use only the Sovereign Squad General Design System and must expose semantic status regions, keyboard access, visible focus, accessible error text, and reduced-motion-safe transitions.
+
+## Observability
+
+Lifecycle telemetry payload:
+
+- `event`
+- `schemaVersion`
+- `unitId`
+- `companyId`
+- `destinationKeys`
+- `reasonCode`
+- `retryable`
+- `recovered`
+- `metrics`
+
+Required events:
+
+- `LIFECYCLE_PROVISIONING_PLAN`
+- `LIFECYCLE_MAINTENANCE_RUN`
+- `DESTINATION_DAEMON_LANE_SYNC`
+- `VISITOR_CONTENT_HEALTH_EVALUATED`
+- `VISITOR_FEEDBACK_POLICY_APPLIED`
+
+## Retries and timeouts
+
+- Provisioning steps are retryable unless marked terminal.
+- Maintenance repairs are idempotent.
+- Heavy repairs must be queued, not executed inline.
+- Low-memory maintenance must pause visibly as `paused_low_memory`.
+- Destination daemon processing remains bounded by existing run/pass/retry limits.
+
+## Rollback and recovery
+
+- Failed provisioning reruns use the same idempotency key where available.
+- Pipeline topology rollback is `mark topology dirty + rerun sync`.
+- Destination rollback is deactivate destination or pause/archive mission definition.
+- Visitor content rollback is retire/unpublish and rerun public verification.
+- Feedback rollback is a compensating rule or rule disablement; policy-changing actions must remain audited.
+
+## Edge cases
+
+- Duplicate Unit provisioning request.
+- Existing destination with stale config.
+- Missing pipeline job.
+- Missing daemon lane.
+- Compare mission using legacy ClassScout policy.
+- Low local memory.
+- Source-only record attempting to publish as listing.
+- Fake/test/placeholder public content.
+- Conflicting feedback rules.
+- Over-broad category ban.
+
+## Testing
+
+Primary contract harness:
+
+```bash
+npm run test:lifecycle-automation-spine
+```
+
+Related harness:
+
+```bash
+npm run test:lifecycle-topology
+```
+
+Production build gate:
+
+```bash
+npm run build
+```
+
+## Operational commands
+
+Run lifecycle maintenance:
+
+```bash
+npm run maintenance:lifecycle
+```
+
+Verify lifecycle health:
+
+```bash
+npm run verify:lifecycle
+```
+
+## Known limitations
+
+- The pure spine is a contract layer; database-specific repair execution still lives in the existing provisioning, maintenance, queue, daemon, and Visitor modules.
+- Future UI issues must render these states through GDS-only surfaces.
+- Migration/backfill for historical data remains a downstream lifecycle issue.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test:sovereign-miniapp-proof-harness": "node scripts/test-sovereign-miniapp-proof-harness.mjs",
     "test:classscout-rulebook-workspace": "node scripts/test-classscout-rulebook-workspace-contract.mjs",
     "test:lifecycle-topology": "node scripts/test-lifecycle-topology.js",
+    "test:lifecycle-automation-spine": "node scripts/test-lifecycle-automation-spine.js",
     "test:local-execution-lanes": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/test-local-execution-lanes.mjs",
     "test:local-runnable-enforcement": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/test-local-runnable-enforcement.mjs",
     "test:local-lane-events": "NODE_ENV=production node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types --experimental-specifier-resolution=node scripts/test-local-lane-events.mjs",

--- a/scripts/test-lifecycle-automation-spine.js
+++ b/scripts/test-lifecycle-automation-spine.js
@@ -1,0 +1,132 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+
+const {
+  buildDestinationDaemonLane,
+  buildLifecycleTelemetry,
+  buildMaintenanceDiff,
+  buildProvisioningPlan,
+  evaluateVisitorFeedbackPolicy,
+  normalizeVisitorFeedbackDecision,
+  scoreVisitorContentHealth,
+} = require("../src/lib/check-lifecycle/lifecycle-spine");
+
+const provisioningPlan = buildProvisioningPlan({
+  companyId: "unit_1",
+  destinationKeys: ["classscout", "compare"],
+  actorId: "operator_1",
+  idempotencyKey: "idem_1",
+});
+
+assert.equal(provisioningPlan.type, "provisioning_plan", "provisioning plan must be typed");
+assert.equal(
+  provisioningPlan.steps.some((step) => step.id === "mission:compare:VISITOR_CONTENT_CURATION"),
+  true,
+  "provisioning must include Compare Visitor content curation mission",
+);
+assert.equal(
+  provisioningPlan.steps.some((step) => step.id === "audit-event"),
+  true,
+  "provisioning must include audit event step",
+);
+
+const maintenanceDiff = buildMaintenanceDiff({
+  destinationKeys: ["compare"],
+  existingPipelineJobs: [],
+  existingMissionKinds: [],
+  stalePublicProjectionIds: ["content_1"],
+});
+
+assert.equal(maintenanceDiff.state, "repairing", "missing lifecycle state must produce repairing state");
+assert.equal(
+  maintenanceDiff.safeRepairs.some((repair) => repair.reasonCode === "missing_pipeline_job"),
+  true,
+  "maintenance diff must repair missing pipeline jobs",
+);
+assert.equal(
+  maintenanceDiff.heavyRepairs.some((repair) => repair.reasonCode === "stale_public_projection"),
+  true,
+  "maintenance diff must enqueue stale public projection verification",
+);
+
+const lowMemoryDiff = buildMaintenanceDiff({ destinationKeys: ["compare"], memoryState: "low" });
+assert.equal(lowMemoryDiff.state, "paused_low_memory", "low memory must surface as explicit pause");
+assert.equal(lowMemoryDiff.metrics.skipped > 0, true, "low memory pause must report skipped work");
+
+const daemonLane = buildDestinationDaemonLane({
+  destinationKeys: ["classscout", "compare"],
+  activeDefinitionIds: ["definition_1"],
+  activeRunIds: ["run_1"],
+});
+
+assert.equal(daemonLane.jobType, "DESTINATION_MISSION_DAEMON", "daemon lane must use destination daemon job");
+assert.equal(daemonLane.entityId, "destination-service", "daemon lane identity must be destination-agnostic");
+assert.equal(daemonLane.metadata.serviceLane, "multi", "multi-destination unit must use multi lane metadata");
+assert.equal(
+  daemonLane.metadata.missionKinds.includes("VISITOR_CONTENT_CURATION"),
+  true,
+  "daemon lane must include Visitor content curation mission kind",
+);
+
+const blockedContent = scoreVisitorContentHealth({
+  sourceTrust: 1,
+  freshness: 1,
+  taxonomyFit: 1,
+  evidenceCompleteness: 1,
+  feedbackFit: 1,
+  sourceOnly: true,
+});
+
+assert.equal(blockedContent.score, 0, "source-only records must hard-block publish score");
+assert.equal(blockedContent.state, "invalid", "source-only records must be invalid");
+assert.equal(blockedContent.publishEligible, false, "source-only records cannot publish");
+
+const healthyContent = scoreVisitorContentHealth({
+  sourceTrust: 1,
+  freshness: 1,
+  taxonomyFit: 1,
+  evidenceCompleteness: 1,
+  feedbackFit: 1,
+  published: true,
+  publicVerificationFresh: true,
+});
+assert.equal(healthyContent.state, "published_verified", "verified published content must surface verified state");
+
+const rule = normalizeVisitorFeedbackDecision({
+  ruleType: "forbidden_category",
+  severity: "block",
+  category: "birthday_party",
+  audience: "hunters",
+  actorId: "operator_1",
+  examples: ["birthday party is wrong for hunting"],
+});
+
+assert.equal(rule.severity, "block", "feedback rule must preserve block severity");
+assert.deepEqual(rule.appliesTo, ["candidate", "published_content"], "feedback applies to future and existing content");
+
+const policyDecision = evaluateVisitorFeedbackPolicy({
+  candidate: { category: "birthday_party", audience: "hunters" },
+  rules: [rule],
+});
+
+assert.equal(policyDecision.decision, "blocked", "block rule must override candidate publish eligibility");
+assert.equal(policyDecision.publishEligible, false, "blocked feedback policy cannot publish");
+assert.equal(policyDecision.refinementRequired, true, "feedback block must trigger refinement");
+
+const telemetry = buildLifecycleTelemetry("LIFECYCLE_MAINTENANCE_RUN", {
+  companyId: "unit_1",
+  destinationKeys: ["compare"],
+  reasonCode: maintenanceDiff.reasonCode,
+  metrics: maintenanceDiff.metrics,
+});
+
+assert.equal(telemetry.event, "LIFECYCLE_MAINTENANCE_RUN", "telemetry event must be preserved");
+assert.equal(telemetry.destinationKeys.includes("compare"), true, "telemetry must include destination keys");
+
+const maintenanceEngineSource = readFileSync(join(process.cwd(), "src/lib/check-lifecycle/maintenance-engine.js"), "utf8");
+assert.match(maintenanceEngineSource, /buildMaintenanceDiff/, "maintenance engine must expose lifecycle diff");
+assert.match(maintenanceEngineSource, /buildDestinationDaemonLane/, "maintenance engine must expose daemon lane metadata");
+assert.match(maintenanceEngineSource, /buildLifecycleTelemetry/, "maintenance engine must expose lifecycle telemetry");
+
+console.log("Lifecycle automation spine contract tests passed.");

--- a/src/lib/check-lifecycle/lifecycle-spine.d.ts
+++ b/src/lib/check-lifecycle/lifecycle-spine.d.ts
@@ -1,0 +1,114 @@
+export type LifecycleRepairReasonCode =
+  | "missing_pipeline_job"
+  | "missing_daemon_lane"
+  | "missing_mission_definition"
+  | "stale_mission_kind"
+  | "stale_public_projection"
+  | "paused_low_memory";
+
+export type LifecycleHealthState =
+  | "healthy"
+  | "repairing"
+  | "degraded"
+  | "blocked"
+  | "paused_low_memory";
+
+export type VisitorContentState =
+  | "fresh"
+  | "stale"
+  | "invalid"
+  | "needs_review"
+  | "retire_pending"
+  | "published_verified";
+
+export function buildProvisioningPlan(input?: {
+  companyId?: string;
+  destinationKeys?: string[];
+  actorId?: string;
+  idempotencyKey?: string;
+  source?: string;
+  now?: string;
+}): {
+  schemaVersion: number;
+  type: "provisioning_plan";
+  destinationKeys: string[];
+  requirements: unknown;
+  steps: Array<Record<string, unknown>>;
+  created: unknown[];
+  repaired: unknown[];
+  skipped: unknown[];
+  failed: unknown[];
+};
+
+export function buildMaintenanceDiff(input?: {
+  destinationKeys?: string[];
+  existingPipelineJobs?: string[];
+  existingMissionKinds?: string[];
+  unsupportedMissionKinds?: string[];
+  stalePublicProjectionIds?: string[];
+  memoryState?: "low" | "normal";
+  pauseReason?: string;
+}): {
+  schemaVersion: number;
+  state: LifecycleHealthState;
+  reasonCode: string;
+  operatorMessage: string;
+  safeRepairs: unknown[];
+  heavyRepairs: unknown[];
+  failures: unknown[];
+  metrics: { inspected: number; repaired: number; failed: number; skipped: number };
+};
+
+export function buildDestinationDaemonLane(input?: {
+  destinationKeys?: string[];
+  activeDefinitionIds?: string[];
+  activeRunIds?: string[];
+}): {
+  schemaVersion: number;
+  jobType: string;
+  entityType: string;
+  entityId: string;
+  metadata: {
+    destinationKeys: string[];
+    missionKinds: string[];
+    activeDefinitionIds: string[];
+    activeRunIds: string[];
+    serviceLane: "single" | "multi";
+    sourceSignal: string;
+  };
+};
+
+export function scoreVisitorContentHealth(input?: {
+  sourceTrust?: number;
+  freshness?: number;
+  taxonomyFit?: number;
+  evidenceCompleteness?: number;
+  feedbackFit?: number;
+  sourceOnly?: boolean;
+  hasSourceEvidence?: boolean;
+  forbiddenCategory?: boolean;
+  fakeOrPlaceholder?: boolean;
+  published?: boolean;
+  publicVerificationFresh?: boolean;
+}): {
+  schemaVersion: number;
+  score: number;
+  state: VisitorContentState;
+  publishEligible: boolean;
+  hardBlocks: string[];
+  recoveryAction: string;
+};
+
+export function normalizeVisitorFeedbackDecision(decision?: Record<string, unknown>): Record<string, unknown>;
+export function evaluateVisitorFeedbackPolicy(input?: {
+  candidate?: Record<string, unknown>;
+  rules?: Array<Record<string, unknown>>;
+}): {
+  schemaVersion: number;
+  decision: string;
+  severity: string;
+  matchedRules: Array<Record<string, unknown>>;
+  publishEligible: boolean;
+  refinementRequired: boolean;
+};
+export function buildLifecycleTelemetry(event: string, payload?: Record<string, unknown>): Record<string, unknown>;

--- a/src/lib/check-lifecycle/lifecycle-spine.js
+++ b/src/lib/check-lifecycle/lifecycle-spine.js
@@ -1,0 +1,364 @@
+const {
+  getDestinationDaemonJobIdentity,
+  getDestinationMissionKinds,
+  getUnitLifecycleRequirements,
+} = require("./topology-registry");
+
+const LIFECYCLE_SPINE_VERSION = 1;
+
+const MAINTENANCE_REASON_CODES = Object.freeze({
+  MISSING_PIPELINE_JOB: "missing_pipeline_job",
+  MISSING_DAEMON_LANE: "missing_daemon_lane",
+  MISSING_MISSION_DEFINITION: "missing_mission_definition",
+  STALE_MISSION_KIND: "stale_mission_kind",
+  STALE_PUBLIC_PROJECTION: "stale_public_projection",
+  PAUSED_LOW_MEMORY: "paused_low_memory",
+});
+
+const VISITOR_CONTENT_STATES = Object.freeze({
+  FRESH: "fresh",
+  STALE: "stale",
+  INVALID: "invalid",
+  NEEDS_REVIEW: "needs_review",
+  RETIRE_PENDING: "retire_pending",
+  PUBLISHED_VERIFIED: "published_verified",
+});
+
+const FEEDBACK_SEVERITY_ORDER = Object.freeze({
+  warn: 1,
+  require_review: 2,
+  retire: 3,
+  block: 4,
+});
+
+function unique(values) {
+  return Array.from(new Set((values || []).map((value) => String(value || "").trim()).filter(Boolean)));
+}
+
+function toSet(values) {
+  return new Set(unique(values));
+}
+
+function normalizeDestinationKeys(destinationKeys) {
+  return unique(destinationKeys).map((value) => value.toLowerCase());
+}
+
+function buildProvisioningPlan(input = {}) {
+  const destinationKeys = normalizeDestinationKeys(input.destinationKeys);
+  const requirements = getUnitLifecycleRequirements({ destinationKeys });
+  const now = input.now || new Date().toISOString();
+  const actorId = input.actorId || "lifecycle-provisioning";
+
+  const steps = [
+    {
+      id: "unit",
+      operation: "upsert_unit",
+      status: "pending",
+      retryable: true,
+      rollback: "delete_or_disable_unit_if_no_external_content_was_published",
+      summary: "Create or verify CHECK Unit company record.",
+      metadata: { companyId: input.companyId || null, actorId, idempotencyKey: input.idempotencyKey || null },
+    },
+    ...requirements.requiredPipelineJobs.map((jobType) => ({
+      id: `pipeline-job:${jobType}`,
+      operation: "ensure_pipeline_job",
+      status: "pending",
+      retryable: true,
+      rollback: "mark_topology_dirty_and_rerun_sync",
+      summary: `Ensure ${jobType} pipeline job exists for the Unit.`,
+      metadata: { jobType },
+    })),
+  ];
+
+  for (const destinationKey of destinationKeys) {
+    steps.push({
+      id: `destination:${destinationKey}`,
+      operation: "ensure_destination_instance",
+      status: "pending",
+      retryable: true,
+      rollback: "deactivate_destination_instance",
+      summary: `Create or verify active ${destinationKey} destination instance.`,
+      metadata: { destinationKey },
+    });
+
+    for (const missionKind of getDestinationMissionKinds(destinationKey)) {
+      steps.push({
+        id: `mission:${destinationKey}:${missionKind}`,
+        operation: "ensure_mission_definition",
+        status: "pending",
+        retryable: true,
+        rollback: "pause_or_archive_mission_definition",
+        summary: `Create or verify active ${missionKind} mission definition for ${destinationKey}.`,
+        metadata: { destinationKey, missionKind },
+      });
+    }
+  }
+
+  steps.push(
+    {
+      id: "topology-dirty",
+      operation: "mark_topology_dirty",
+      status: "pending",
+      retryable: true,
+      rollback: "rerun_lifecycle_maintenance",
+      summary: "Mark topology and projections dirty after provisioning mutation.",
+      metadata: { reason: "lifecycle-provisioning", at: now },
+    },
+    {
+      id: "audit-event",
+      operation: "record_lifecycle_audit_event",
+      status: "pending",
+      retryable: false,
+      rollback: "append_compensating_audit_event",
+      summary: "Record provisioning audit event with actor, idempotency key, and recovery hint.",
+      metadata: { actorId, source: input.source || "provisioning-engine", at: now },
+    },
+  );
+
+  return {
+    schemaVersion: LIFECYCLE_SPINE_VERSION,
+    type: "provisioning_plan",
+    destinationKeys,
+    requirements,
+    steps,
+    created: [],
+    repaired: [],
+    skipped: [],
+    failed: [],
+  };
+}
+
+function buildMaintenanceDiff(input = {}) {
+  const destinationKeys = normalizeDestinationKeys(input.destinationKeys);
+  const requirements = getUnitLifecycleRequirements({ destinationKeys });
+  const existingJobs = toSet(input.existingPipelineJobs);
+  const existingMissionKinds = toSet(input.existingMissionKinds);
+  const safeRepairs = [];
+  const heavyRepairs = [];
+  const failures = [];
+
+  if (input.memoryState === "low" || input.pauseReason === MAINTENANCE_REASON_CODES.PAUSED_LOW_MEMORY) {
+    return {
+      schemaVersion: LIFECYCLE_SPINE_VERSION,
+      state: "paused_low_memory",
+      reasonCode: MAINTENANCE_REASON_CODES.PAUSED_LOW_MEMORY,
+      operatorMessage: "Lifecycle maintenance paused because local memory is below the safe execution band.",
+      safeRepairs,
+      heavyRepairs,
+      failures,
+      metrics: { inspected: 0, repaired: 0, failed: 0, skipped: requirements.requiredPipelineJobs.length },
+    };
+  }
+
+  for (const jobType of requirements.requiredPipelineJobs) {
+    if (!existingJobs.has(jobType)) {
+      safeRepairs.push({
+        reasonCode: MAINTENANCE_REASON_CODES.MISSING_PIPELINE_JOB,
+        operation: "ensure_pipeline_job",
+        retryable: true,
+        summary: `Repair missing ${jobType} pipeline job.`,
+        metadata: { jobType },
+      });
+    }
+  }
+
+  for (const missionKind of requirements.requiredMissionKinds) {
+    if (!existingMissionKinds.has(missionKind)) {
+      safeRepairs.push({
+        reasonCode: MAINTENANCE_REASON_CODES.MISSING_MISSION_DEFINITION,
+        operation: "ensure_mission_definition",
+        retryable: true,
+        summary: `Repair missing ${missionKind} destination mission definition.`,
+        metadata: { missionKind },
+      });
+    }
+  }
+
+  for (const missionKind of unique(input.unsupportedMissionKinds)) {
+    failures.push({
+      reasonCode: MAINTENANCE_REASON_CODES.STALE_MISSION_KIND,
+      retryable: false,
+      recovery: "Run lifecycle migration/backfill before scheduling this mission.",
+      summary: `Unsupported mission kind ${missionKind} must be migrated before execution.`,
+      metadata: { missionKind },
+    });
+  }
+
+  for (const contentId of unique(input.stalePublicProjectionIds)) {
+    heavyRepairs.push({
+      reasonCode: MAINTENANCE_REASON_CODES.STALE_PUBLIC_PROJECTION,
+      operation: "enqueue_public_verification",
+      retryable: true,
+      summary: "Queue public verification for stale Visitor projection.",
+      metadata: { contentId },
+    });
+  }
+
+  const state = failures.length > 0
+    ? "blocked"
+    : safeRepairs.length > 0 || heavyRepairs.length > 0
+      ? "repairing"
+      : "healthy";
+
+  return {
+    schemaVersion: LIFECYCLE_SPINE_VERSION,
+    state,
+    reasonCode: state === "healthy" ? "lifecycle_healthy" : "lifecycle_diff_detected",
+    operatorMessage: state === "healthy"
+      ? "Lifecycle requirements are satisfied."
+      : "Lifecycle maintenance found repairable or blocked drift.",
+    safeRepairs,
+    heavyRepairs,
+    failures,
+    metrics: {
+      inspected: requirements.requiredPipelineJobs.length + requirements.requiredMissionKinds.length,
+      repaired: safeRepairs.length + heavyRepairs.length,
+      failed: failures.length,
+      skipped: 0,
+    },
+  };
+}
+
+function buildDestinationDaemonLane(input = {}) {
+  const destinationKeys = normalizeDestinationKeys(input.destinationKeys);
+  const missionKinds = unique(destinationKeys.flatMap((destinationKey) => getDestinationMissionKinds(destinationKey)));
+  const identity = getDestinationDaemonJobIdentity();
+  return {
+    schemaVersion: LIFECYCLE_SPINE_VERSION,
+    ...identity,
+    metadata: {
+      destinationKeys,
+      missionKinds,
+      activeDefinitionIds: unique(input.activeDefinitionIds),
+      activeRunIds: unique(input.activeRunIds),
+      serviceLane: destinationKeys.length > 1 ? "multi" : "single",
+      sourceSignal: destinationKeys.length
+        ? `Destination daemon lane covers ${destinationKeys.join(", ")} for ${missionKinds.join(", ")}.`
+        : "Destination daemon lane has no active destinations.",
+    },
+  };
+}
+
+function scoreVisitorContentHealth(input = {}) {
+  const hardBlocks = [];
+  if (input.sourceOnly === true) hardBlocks.push("source_only_record");
+  if (input.hasSourceEvidence === false) hardBlocks.push("missing_source_evidence");
+  if (input.forbiddenCategory === true) hardBlocks.push("forbidden_category");
+  if (input.fakeOrPlaceholder === true) hardBlocks.push("fake_or_placeholder_content");
+
+  const score = hardBlocks.length > 0
+    ? 0
+    : Math.round(
+      100 * (
+        0.35 * Number(input.sourceTrust || 0)
+        + 0.25 * Number(input.freshness || 0)
+        + 0.20 * Number(input.taxonomyFit || 0)
+        + 0.15 * Number(input.evidenceCompleteness || 0)
+        + 0.05 * Number(input.feedbackFit || 0)
+      ),
+    );
+
+  const state = hardBlocks.length > 0
+    ? VISITOR_CONTENT_STATES.INVALID
+    : input.published === true && input.publicVerificationFresh === true
+      ? VISITOR_CONTENT_STATES.PUBLISHED_VERIFIED
+      : score >= 80
+        ? VISITOR_CONTENT_STATES.FRESH
+        : score >= 55
+          ? VISITOR_CONTENT_STATES.NEEDS_REVIEW
+          : VISITOR_CONTENT_STATES.STALE;
+
+  return {
+    schemaVersion: LIFECYCLE_SPINE_VERSION,
+    score,
+    state,
+    publishEligible: hardBlocks.length === 0 && score >= 80,
+    hardBlocks,
+    recoveryAction: hardBlocks.length > 0
+      ? "repair_evidence_or_retire_content"
+      : score >= 80
+        ? "verify_or_publish"
+        : "queue_maintenance_review",
+  };
+}
+
+function normalizeVisitorFeedbackDecision(decision = {}) {
+  const severity = FEEDBACK_SEVERITY_ORDER[decision.severity] ? decision.severity : "require_review";
+  const appliesTo = unique(decision.appliesTo && decision.appliesTo.length ? decision.appliesTo : ["candidate", "published_content"]);
+  return {
+    schemaVersion: LIFECYCLE_SPINE_VERSION,
+    ruleType: decision.ruleType || "audience_mismatch",
+    severity,
+    appliesTo,
+    category: decision.category || null,
+    audience: decision.audience || null,
+    source: decision.source || null,
+    examples: unique(decision.examples),
+    counterexamples: unique(decision.counterexamples),
+    actorId: decision.actorId || "unknown",
+    reason: decision.reason || "Operator feedback converted to lifecycle policy.",
+  };
+}
+
+function evaluateVisitorFeedbackPolicy(input = {}) {
+  const candidate = input.candidate || {};
+  const rules = Array.isArray(input.rules) ? input.rules : [];
+  const matchedRules = rules.filter((rule) => {
+    if (rule.category && candidate.category && rule.category !== candidate.category) return false;
+    if (rule.audience && candidate.audience && rule.audience !== candidate.audience) return false;
+    if (rule.source && candidate.source && rule.source !== candidate.source) return false;
+    return true;
+  });
+
+  const highest = matchedRules.reduce((current, rule) => {
+    const value = FEEDBACK_SEVERITY_ORDER[rule.severity] || 0;
+    return value > current.value ? { value, severity: rule.severity } : current;
+  }, { value: 0, severity: "none" });
+
+  const decision = highest.severity === "block"
+    ? "blocked"
+    : highest.severity === "retire"
+      ? "retire_pending"
+      : highest.severity === "require_review"
+        ? "requires_human_review"
+        : highest.severity === "warn"
+          ? "warn"
+          : "allowed";
+
+  return {
+    schemaVersion: LIFECYCLE_SPINE_VERSION,
+    decision,
+    severity: highest.severity,
+    matchedRules,
+    publishEligible: decision === "allowed" || decision === "warn",
+    refinementRequired: decision !== "allowed",
+  };
+}
+
+function buildLifecycleTelemetry(event, payload = {}) {
+  return {
+    event,
+    schemaVersion: LIFECYCLE_SPINE_VERSION,
+    unitId: payload.unitId || payload.companyId || null,
+    companyId: payload.companyId || null,
+    destinationKeys: normalizeDestinationKeys(payload.destinationKeys),
+    reasonCode: payload.reasonCode || "lifecycle_event",
+    retryable: payload.retryable !== false,
+    recovered: payload.recovered === true,
+    metrics: payload.metrics || {},
+  };
+}
+
+module.exports = {
+  FEEDBACK_SEVERITY_ORDER,
+  LIFECYCLE_SPINE_VERSION,
+  MAINTENANCE_REASON_CODES,
+  VISITOR_CONTENT_STATES,
+  buildDestinationDaemonLane,
+  buildLifecycleTelemetry,
+  buildMaintenanceDiff,
+  buildProvisioningPlan,
+  evaluateVisitorFeedbackPolicy,
+  normalizeVisitorFeedbackDecision,
+  scoreVisitorContentHealth,
+};

--- a/src/lib/check-lifecycle/maintenance-engine.d.ts
+++ b/src/lib/check-lifecycle/maintenance-engine.d.ts
@@ -18,6 +18,9 @@ export function maintainCompanyLifecycle(prisma: unknown, input: string | {
   requiredMissionKinds?: string[];
   jobCount?: number;
   daemonJobs?: unknown[];
+  daemonLane?: unknown;
+  lifecycleHealth?: unknown;
+  telemetry?: unknown;
   steps: MaintenanceStepResult[];
 }>;
 

--- a/src/lib/check-lifecycle/maintenance-engine.js
+++ b/src/lib/check-lifecycle/maintenance-engine.js
@@ -4,6 +4,11 @@ const {
   getUnitLifecycleRequirements,
   listLifecycleDestinationKeys,
 } = require("./topology-registry");
+const {
+  buildDestinationDaemonLane,
+  buildLifecycleTelemetry,
+  buildMaintenanceDiff,
+} = require("./lifecycle-spine");
 const { syncCompanyPipelineJobs } = require("../pipeline-queue");
 
 function getDefaultRulebookPolicyForDestination(destinationKey) {
@@ -293,6 +298,17 @@ async function maintainCompanyLifecycle(prisma, input) {
     select: { id: true, entityType: true, entityId: true, status: true, metadata: true },
   });
   const requirements = getUnitLifecycleRequirements({ destinationKeys });
+  const lifecycleHealth = buildMaintenanceDiff({
+    destinationKeys,
+    existingPipelineJobs: jobs.map((job) => job.jobType).filter(Boolean),
+    existingMissionKinds: requirements.requiredMissionKinds,
+  });
+  const daemonLane = buildDestinationDaemonLane({
+    destinationKeys,
+    activeDefinitionIds: steps
+      .map((step) => step.metadata && step.metadata.missionDefinitionId)
+      .filter(Boolean),
+  });
 
   return {
     ok: true,
@@ -303,6 +319,15 @@ async function maintainCompanyLifecycle(prisma, input) {
     requiredMissionKinds: requirements.requiredMissionKinds,
     jobCount: jobs.length,
     daemonJobs,
+    daemonLane,
+    lifecycleHealth,
+    telemetry: buildLifecycleTelemetry("LIFECYCLE_MAINTENANCE_RUN", {
+      companyId,
+      destinationKeys,
+      reasonCode: lifecycleHealth.reasonCode,
+      recovered: lifecycleHealth.metrics.repaired > 0,
+      metrics: lifecycleHealth.metrics,
+    }),
     steps,
   };
 }


### PR DESCRIPTION
## Scope
Implements the next Lifecycle Automation execution slice:

- Closes #353
- Closes #354
- Closes #355
- Closes #356
- Closes #357

## Implementation
- Adds a deterministic lifecycle spine contract layer for provisioning plans, maintenance diffs, destination daemon lane metadata, Visitor content health, feedback rule normalization/evaluation, and lifecycle telemetry.
- Extends maintenance-engine results with lifecycleHealth, daemonLane, and telemetry without removing existing response fields.
- Adds TypeScript declarations for the new spine contracts.
- Adds a database-free lifecycle automation regression harness.
- Adds CHECK lifecycle automation LLD/runbook covering architecture, runtime flow, APIs, UX states, observability, retries/timeouts, rollback/recovery, edge cases, testing, and operational commands.

## Validation
- npm run test:lifecycle-automation-spine
- npm run test:lifecycle-topology
- npm run build
